### PR TITLE
Changes to sparse checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@ These are all the options available to configure this plugin's behaviour.
 
 #### `paths` (list of string)
 
-Paths accepted by `git sparse-checkout add`.
+Paths accepted by `git sparse-checkout set`.
+
+### Optional
+
+#### `no_cone` ('true' or 'false')
+
+Whether to pass `--no-cone` to `git sparse-checkout` so that the paths are considered to by a list of patterns.
 
 ## Examples
 
@@ -24,6 +30,18 @@ steps:
       - sparse-checkout:
           paths:
             - .buildkite
+```
+
+```yaml
+steps:
+  - label: "Pipeline upload"
+    command: "buildkite-agent pipeline upload"
+    plugins:
+      - sparse-checkout:
+          no_cone: true
+          paths:
+            - .buildkite
+            - helm*
 ```
 
 ## ⚒ Developing

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -7,30 +7,37 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 # shellcheck source=lib/plugin.bash
 . "$DIR/../lib/plugin.bash"
 
-CHECKOUT_PATHS=$(plugin_read_config PATHS "")
-
-if [ -z "${CHECKOUT_PATHS}" ]; then
-  echo 'Missing `paths` option in the plugin'
-  exit 1
+if plugin_read_list_into_result PATHS; then
+    CHECKOUT_PATHS=("${result[@]}")
+else
+    echo "Missing 'paths' option in the plugin"
+    exit 1
 fi
 
-echo "Creating sparse-checkout with paths: ${CHECKOUT_PATHS}"
+echo "Scanning SSH keys for remote git repository"
+[[ -d ~/.ssh ]] || mkdir -p ~/.ssh
+ssh-keyscan "${BUILDKITE_REPO_SSH_HOST}" >> ~/.ssh/known_hosts
+
+echo "Creating sparse-checkout with paths: ${CHECKOUT_PATHS[*]}"
 
 # clone the repo without checking out files if it does not exist already
-if [ ! -d .git ]; then
-    git clone -v --depth 1 --no-checkout ${BUILDKITE_REPO} .
+if [[ ! -d .git ]]; then
+    git clone \
+        --depth 1 \
+        --filter=blob:none \
+        --no-checkout \
+        ${BUILDKITE_REPO_MIRROR:+--reference "$BUILDKITE_REPO_MIRROR"} \
+        -v \
+        "${BUILDKITE_REPO}" .
 fi
 
 git clean -ffxdq
 # fetch branch if commit is HEAD
-if [ "${BUILDKITE_COMMIT}" = "HEAD" ]; then
-    git fetch origin ${BUILDKITE_BRANCH}
-    git checkout FETCH_HEAD
+if [[ ${BUILDKITE_COMMIT} = "HEAD" ]]; then
+    git fetch --depth 1 origin "${BUILDKITE_BRANCH}"
 else
-    git fetch origin ${BUILDKITE_COMMIT}
-    git checkout ${BUILDKITE_COMMIT}
+    git fetch --depth 1 origin "${BUILDKITE_COMMIT}"
 fi
 
-git sparse-checkout init
-git sparse-checkout add ${CHECKOUT_PATHS}
+git sparse-checkout set --no-cone "${CHECKOUT_PATHS[@]}"
 git checkout

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -7,6 +7,10 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 # shellcheck source=lib/plugin.bash
 . "$DIR/../lib/plugin.bash"
 
+NO_CONE_OPTION="$(plugin_read_config NO_CONE "false")"
+NO_CONE_PARAM=""
+[[ $NO_CONE_OPTION = false ]] || NO_CONE_PARAM="--no-cone"
+
 if plugin_read_list_into_result PATHS; then
     CHECKOUT_PATHS=("${result[@]}")
 else
@@ -39,5 +43,9 @@ else
     git fetch --depth 1 origin "${BUILDKITE_COMMIT}"
 fi
 
-git sparse-checkout set --no-cone "${CHECKOUT_PATHS[@]}"
-git checkout
+git sparse-checkout set ${NO_CONE_PARAM:+--no-cone} "${CHECKOUT_PATHS[@]}"
+if [[ ${BUILDKITE_COMMIT} = "HEAD" ]]; then
+   git checkout FETCH_HEAD
+else
+   git checkout "${BUILDKITE_COMMIT}"
+fi


### PR DESCRIPTION
The existing code checkout downloaded more data than it needed to. This is an attempt to make it more sparse and to fix some potential bugs.

Turn `CHECKOUT_PATHS` into an array so that multiple paths can be used.

Add a step to scan SSH keys of the remote git host.

Add `--filter=blob:none` to the `git clone` so that file contents are not downloaded until needed by git.

If `$BUILDKITE_REPO_MIRROR` is set, then pass it as `--reference` to `git clone`. This is for users using the Buildkite repository mirror functionality.

Add `--depth 1` to the `git fetch` commands for a shallow clone to checkout only necessary data.

Remove the deprecated `git sparse-checkout init` command.

Use `git set` in place of `git add` and pass the `--no-cone` option so that the paths passed in can match files and patterns.

The `git checkout` needs to happen after the `git sparse-checkout` command has been run.
Doing it beforehand checkouts out all files in the repository, which defeats the purpose of performing a sparse checkout.

This is a `bash` script so use `[[ ]]` in place of `[ ]` and there is no need to quote the variables within `[[ ]]` like there was before.

Quote other uses of the variables to fix warnings from shellcheck.