### PR TITLE
Use custom directory for checkout

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+# suffix the checkout path to ensure this plugin makes use of a unique directory
+# this is so any subsequent builds for this pipeline (in the default directory) on the same agent are not messed up by the sparse checkout logic
+export BUILDKITE_BUILD_CHECKOUT_PATH=${BUILDKITE_BUILD_CHECKOUT_PATH}-sparse


### PR DESCRIPTION
This updates the checkout path to use a unique value so it doesn't mess with subsequent builds on the same agent that
dont use this plugin
