### PR TITLE
Add additional option to skip ssh-keyscan, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Paths accepted by `git sparse-checkout set`.
 
 Whether to pass `--no-cone` to `git sparse-checkout` so that the paths are considered to be a list of patterns.
 
+#### `skip_ssh_keyscan` ('true' or 'false')
+
+Whether to skip ssh-keyscan step. This will skip adding each ssh public key into the known-hosts file. Only use if ssh keys are already setup.
+
 ## Example
 
 Below is an example for using sparse-checkout plugin.

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -11,6 +11,8 @@ NO_CONE_OPTION="$(plugin_read_config NO_CONE "false")"
 NO_CONE_PARAM=""
 [[ $NO_CONE_OPTION = false ]] || NO_CONE_PARAM="--no-cone"
 
+SKIP_SSH_KEYSCAN_OPTION="$(plugin_read_config SKIP_SSH_KEYSCAN "false")"
+
 if plugin_read_list_into_result PATHS; then
     CHECKOUT_PATHS=("${result[@]}")
 else
@@ -18,9 +20,11 @@ else
     exit 1
 fi
 
-echo "Scanning SSH keys for remote git repository"
-[[ -d ~/.ssh ]] || mkdir -p ~/.ssh
-ssh-keyscan "${BUILDKITE_REPO_SSH_HOST}" >> ~/.ssh/known_hosts
+if [[ "$SKIP_SSH_KEYSCAN_OPTION" != "false" ]]; then
+    echo "Scanning SSH keys for remote git repository"
+    [[ -d ~/.ssh ]] || mkdir -p ~/.ssh
+    ssh-keyscan "${BUILDKITE_REPO_SSH_HOST}" >> ~/.ssh/known_hosts
+fi
 
 echo "Creating sparse-checkout with paths: ${CHECKOUT_PATHS[*]}"
 

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -25,7 +25,7 @@ if [ "$SKIP_SSH_KEYSCAN_OPTION" = "false" ]; then
     [[ -d ~/.ssh ]] || mkdir -p ~/.ssh
     ssh-keyscan "${BUILDKITE_REPO_SSH_HOST}" >> ~/.ssh/known_hosts
 else
-    echo "Skiped SSH keyscan"
+    echo "Skipped SSH keyscan"
 fi
 
 echo "Creating sparse-checkout with paths: ${CHECKOUT_PATHS[*]}"

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -11,8 +11,6 @@ NO_CONE_OPTION="$(plugin_read_config NO_CONE "false")"
 NO_CONE_PARAM=""
 [[ $NO_CONE_OPTION = false ]] || NO_CONE_PARAM="--no-cone"
 
-SKIP_SSH_KEYSCAN_OPTION="$(plugin_read_config SKIP_SSH_KEYSCAN "false")"
-
 if plugin_read_list_into_result PATHS; then
     CHECKOUT_PATHS=("${result[@]}")
 else
@@ -20,10 +18,15 @@ else
     exit 1
 fi
 
-if [[ "$SKIP_SSH_KEYSCAN_OPTION" != "false" ]]; then
+SKIP_SSH_KEYSCAN_OPTION="$(plugin_read_config SKIP_SSH_KEYSCAN "false")"
+echo "SKIP_SSH_KEYSCAN_OPTION: $SKIP_SSH_KEYSCAN_OPTION"
+
+if [ "$SKIP_SSH_KEYSCAN_OPTION" = "false" ]; then
     echo "Scanning SSH keys for remote git repository"
     [[ -d ~/.ssh ]] || mkdir -p ~/.ssh
     ssh-keyscan "${BUILDKITE_REPO_SSH_HOST}" >> ~/.ssh/known_hosts
+else
+    echo "Skipping SSH keyscan"
 fi
 
 echo "Creating sparse-checkout with paths: ${CHECKOUT_PATHS[*]}"

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -19,14 +19,13 @@ else
 fi
 
 SKIP_SSH_KEYSCAN_OPTION="$(plugin_read_config SKIP_SSH_KEYSCAN "false")"
-echo "SKIP_SSH_KEYSCAN_OPTION: $SKIP_SSH_KEYSCAN_OPTION"
 
 if [ "$SKIP_SSH_KEYSCAN_OPTION" = "false" ]; then
     echo "Scanning SSH keys for remote git repository"
     [[ -d ~/.ssh ]] || mkdir -p ~/.ssh
     ssh-keyscan "${BUILDKITE_REPO_SSH_HOST}" >> ~/.ssh/known_hosts
 else
-    echo "Skipping SSH keyscan"
+    echo "Skiped SSH keyscan"
 fi
 
 echo "Creating sparse-checkout with paths: ${CHECKOUT_PATHS[*]}"

--- a/plugin.yml
+++ b/plugin.yml
@@ -10,6 +10,9 @@ configuration:
     no_cone:
       type: boolean
       default: false
+    skip_ssh_keyscan:
+      type: boolean
+      default: false
   required:
     - paths
   additionalProperties: false

--- a/tests/checkout.bats
+++ b/tests/checkout.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+
+setup() {
+  load "${BATS_PLUGIN_PATH}/load.bash"
+
+  # Uncomment to enable stub debugging
+  # export CURL_STUB_DEBUG=/dev/tty
+
+  # you can set variables common to all tests here
+  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_PATHS="default_path"
+  export BUILDKITE_REPO_SSH_HOST="default_host"
+  export BUILDKITE_COMMIT="dummy-commit-hash"
+}
+
+@test "Skip ssh-keyscan when option provided" {
+  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_SKIP_SSH_KEYSCAN='true'
+
+  stub git "clean \* : echo 'git clean'"
+  stub git "fetch --depth 1 origin \* : echo 'git fetch'"
+  stub git "sparse-checkout set \* \* : echo 'git sparse-checkout'" 
+  stub git "checkout \* : echo 'checkout'"
+
+  run "$PWD"/hooks/checkout
+
+  assert_success
+  assert_output --partial 'Skipped SSH keyscan'
+
+  unstub git
+}
+
+@test "Run ssh-keyscan when no option provided" {
+  unset BUILDKITE_PLUGIN_SPARSE_CHECKOUT_SKIP_SSH_KEYSCAN
+  
+  stub ssh-keyscan "\* : echo 'keyscan'"
+  stub git "clean \* : echo 'git clean'"
+  stub git "fetch --depth 1 origin \* : echo 'git fetch'"
+  stub git "sparse-checkout set \* \* : echo 'git sparse-checkout'" 
+  stub git "checkout \* : echo 'checkout'"
+
+  run "$PWD"/hooks/checkout
+
+  assert_success
+  assert_output --partial 'Scanning SSH keys for remote git repository'
+  
+  unstub git
+  unstub ssh-keyscan
+}


### PR DESCRIPTION
Allows an additional option to skip the ssh-keyscan step. This results in 2-3 seconds saved for each sparse clone that we are doing. :D 

Before
<img width="1682" alt="Screenshot 2024-10-01 at 4 23 45 PM" src="https://github.com/user-attachments/assets/3f2bbf49-9a70-42d3-85fd-9519df52f21f">


After
<img width="1650" alt="Screenshot 2024-10-01 at 4 23 25 PM" src="https://github.com/user-attachments/assets/06276e9a-ba3f-455c-ba20-4628d6b00246">
