### PR TITLE
Skip ssh-keyscan when BUILDKITE_REPO_SSH_HOST is unset

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -20,7 +20,7 @@ fi
 
 SKIP_SSH_KEYSCAN_OPTION="$(plugin_read_config SKIP_SSH_KEYSCAN "false")"
 
-if [ "$SKIP_SSH_KEYSCAN_OPTION" = "false" ]; then
+if [[ -n "${BUILDKITE_REPO_SSH_HOST:-}" ]] && [[ "${SKIP_SSH_KEYSCAN_OPTION}" = "false" ]] ; then
     echo "Scanning SSH keys for remote git repository"
     [[ -d ~/.ssh ]] || mkdir -p ~/.ssh
     ssh-keyscan "${BUILDKITE_REPO_SSH_HOST}" >> ~/.ssh/known_hosts


### PR DESCRIPTION
Run `ssh-keyscan` when `BUILDKITE_REPO_SSH_HOST` is defined and `skip_ssh_keyscan` is NOT set to `true`.

Fixes: https://github.com/buildkite-plugins/sparse-checkout-buildkite-plugin/issues/11