### PR TITLE
[SUP-4697] Adding a clean checkout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ Whether to skip ssh-keyscan step. This will skip adding each ssh public key into
 
 #### `clean_checkout` ('true' or 'false')
 
-Whether to perform aggressive repository cleanup before checkout. This option handles scenarios where interrupted or cancelled jobs leave the git repository in a corrupted state with uncommitted changes that would prevent checkout. When enabled, it performs `git reset --hard HEAD` and `git sparse-checkout disable` in addition to the normal cleanup. Use this option for pipeline upload jobs that don't need to preserve local changes.
+Whether to perform aggressive repository cleanup before checkout. This option handles scenarios where interrupted or cancelled jobs leave the git repository in a corrupted state with uncommitted changes that would prevent checkout. When enabled, it performs `git reset --hard HEAD` and `git sparse-checkout disable` in addition to the normal cleanup. 
+
+**⚠️ Warning:** This option will destroy ALL local changes and remove ALL untracked files. The `git clean -ffxdq` command with the `-x` flag will also remove ignored files (such as credentials, local configuration, or cache files). Only use this option when you're certain no important local data needs to be preserved.
+
+Use this option for pipeline upload jobs that don't need to preserve local changes.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Whether to pass `--no-cone` to `git sparse-checkout` so that the paths are consi
 
 Whether to skip ssh-keyscan step. This will skip adding each ssh public key into the known-hosts file. Only use if ssh keys are already setup.
 
+#### `clean_checkout` ('true' or 'false')
+
+Whether to perform aggressive repository cleanup before checkout. This option handles scenarios where interrupted or cancelled jobs leave the git repository in a corrupted state with uncommitted changes that would prevent checkout. When enabled, it performs `git reset --hard HEAD` and `git sparse-checkout disable` in addition to the normal cleanup. Use this option for pipeline upload jobs that don't need to preserve local changes.
+
 ## Example
 
 Below is an example for using sparse-checkout plugin.
@@ -36,6 +40,21 @@ steps:
       - sparse-checkout#v1.1.0:
           paths:
             - .buildkite
+```
+
+### Handling Corrupted Repository States
+
+If your jobs are frequently cancelled during the git clone phase, you may encounter failures due to uncommitted changes left in the repository. Use the `clean_checkout` option to handle this:
+
+```yaml
+steps:
+  - label: "Pipeline upload with clean checkout"
+    command: "buildkite-agent pipeline upload"
+    plugins:
+      - sparse-checkout#v1.1.0:
+          paths:
+            - .buildkite
+          clean_checkout: true
 ```
 
 ## ⚒ Developing

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ steps:
             - .buildkite
 ```
 
-### Handling Corrupted Repository States
+### Handling corrupted repository states
 
 If your jobs are frequently cancelled during the git clone phase, you may encounter failures due to uncommitted changes left in the repository. Use the `clean_checkout` option to handle this:
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Whether to perform aggressive repository cleanup before checkout. This option ha
 
 ## Example
 
-Below is an example for using sparse-checkout plugin.
+Below is an example of using sparse-checkout plugin.
 
 ```yaml
 steps:

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -42,7 +42,7 @@ if [[ ! -d .git ]]; then
         "${BUILDKITE_REPO}" .
 fi
 
-# Handle clean checkout option to deal with corrupted repository states
+# Enable clean checkout option to deal with corrupted repository states
 if [[ "${CLEAN_CHECKOUT_OPTION}" = "true" ]]; then
     echo "Clean checkout enabled - resetting repository state"
     # Reset any changes that might prevent checkout

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -21,6 +21,10 @@ fi
 SKIP_SSH_KEYSCAN_OPTION="$(plugin_read_config SKIP_SSH_KEYSCAN "false")"
 CLEAN_CHECKOUT_OPTION="$(plugin_read_config CLEAN_CHECKOUT "false")"
 
+if [[ "${CLEAN_CHECKOUT_OPTION}" = "true" ]]; then
+    echo "⚠️  WARNING: clean_checkout is enabled - this will destroy any local changes and reset the repository state"
+fi
+
 if [[ -n "${BUILDKITE_REPO_SSH_HOST:-}" ]] && [[ "${SKIP_SSH_KEYSCAN_OPTION}" = "false" ]] ; then
     echo "Scanning SSH keys for remote git repository"
     [[ -d ~/.ssh ]] || mkdir -p ~/.ssh
@@ -45,15 +49,23 @@ fi
 # Enable clean checkout option to deal with corrupted repository states
 if [[ "${CLEAN_CHECKOUT_OPTION}" = "true" ]]; then
     echo "Clean checkout enabled - resetting repository state"
-    # Reset any changes that might prevent checkout
-    git reset --hard HEAD 2>/dev/null || true
-    # Clean all untracked files and directories
-    git clean -ffxdq
-    # Reset sparse-checkout configuration
-    git sparse-checkout disable 2>/dev/null || true
-else
-    git clean -ffxdq
-fi
+    # Remove index lock files
+    find .git -name "*.lock" -delete 2>/dev/null || true
+    # Reset index if corrupted
+      if ! git status >/dev/null 2>&1; then
+          rm -f .git/index 2>/dev/null || true
+      fi
+    # Disable sparse-checkout
+      git sparse-checkout disable 2>/dev/null || true
+    # Clean and reset
+      git clean -ffxdq
+
+      if git rev-parse --verify HEAD >/dev/null 2>&1; then
+          git reset --hard HEAD
+      fi
+  else
+      git clean -ffxdq
+  fi
 
 FETCH_FLAGS=()
 if [[ -n "${BUILDKITE_GIT_FETCH_FLAGS:-}" ]]; then

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -19,6 +19,7 @@ else
 fi
 
 SKIP_SSH_KEYSCAN_OPTION="$(plugin_read_config SKIP_SSH_KEYSCAN "false")"
+CLEAN_CHECKOUT_OPTION="$(plugin_read_config CLEAN_CHECKOUT "false")"
 
 if [[ -n "${BUILDKITE_REPO_SSH_HOST:-}" ]] && [[ "${SKIP_SSH_KEYSCAN_OPTION}" = "false" ]] ; then
     echo "Scanning SSH keys for remote git repository"
@@ -41,7 +42,18 @@ if [[ ! -d .git ]]; then
         "${BUILDKITE_REPO}" .
 fi
 
-git clean -ffxdq
+# Handle clean checkout option to deal with corrupted repository states
+if [[ "${CLEAN_CHECKOUT_OPTION}" = "true" ]]; then
+    echo "Clean checkout enabled - resetting repository state"
+    # Reset any changes that might prevent checkout
+    git reset --hard HEAD 2>/dev/null || true
+    # Clean all untracked files and directories
+    git clean -ffxdq
+    # Reset sparse-checkout configuration
+    git sparse-checkout disable 2>/dev/null || true
+else
+    git clean -ffxdq
+fi
 
 FETCH_FLAGS=()
 if [[ -n "${BUILDKITE_GIT_FETCH_FLAGS:-}" ]]; then

--- a/plugin.yml
+++ b/plugin.yml
@@ -13,6 +13,9 @@ configuration:
     skip_ssh_keyscan:
       type: boolean
       default: false
+    clean_checkout:
+      type: boolean
+      default: false
   required:
     - paths
   additionalProperties: false

--- a/tests/checkout.bats
+++ b/tests/checkout.bats
@@ -124,9 +124,11 @@ setup() {
   export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEAN_CHECKOUT="true"
 
   stub ssh-keyscan "* : echo 'keyscan'"
-  stub git "reset --hard HEAD : echo 'git reset hard'"
-  stub git "clean -ffxdq : echo 'git clean aggressive'"
+  stub git "status : echo 'status ok'"
   stub git "sparse-checkout disable : echo 'git sparse-checkout disable'"
+  stub git "clean -ffxdq : echo 'git clean aggressive'"
+  stub git "rev-parse --verify HEAD : echo 'HEAD'"
+  stub git "reset --hard HEAD : echo 'git reset hard'"
   stub git "fetch --depth 1 origin * : echo 'git fetch'"
   stub git "sparse-checkout set * * : echo 'git sparse-checkout'"
   stub git "checkout * : echo 'checkout'"
@@ -147,9 +149,10 @@ setup() {
   export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEAN_CHECKOUT="true"
 
   stub ssh-keyscan "* : echo 'keyscan'"
-  stub git "reset --hard HEAD : exit 1"  # simulate failure
-  stub git "clean -ffxdq : echo 'git clean'"
+  stub git "status : echo 'status ok'"
   stub git "sparse-checkout disable : echo 'sparse-checkout disable'"
+  stub git "clean -ffxdq : echo 'git clean'"
+  stub git "rev-parse --verify HEAD : exit 1"
   stub git "fetch --depth 1 origin * : echo 'git fetch'"
   stub git "sparse-checkout set * * : echo 'git sparse-checkout'"
   stub git "checkout * : echo 'checkout'"

--- a/tests/checkout.bats
+++ b/tests/checkout.bats
@@ -101,7 +101,7 @@ setup() {
   unstub git
 }
 
-@test "Clean checkout disabled uses normal git clean" {
+@test "Clean checkout disabled - uses normal git clean" {
   export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEAN_CHECKOUT="false"
 
   stub ssh-keyscan "* : echo 'keyscan'"


### PR DESCRIPTION
This PR adds a clean_checkout option (default: false) to fix failures caused by interrupted or canceled Buildkite jobs leaving the repo in a dirty state. When enabled, it aggressively resets the repo to prevent checkout failures caused by leftover changes.

