### PR TITLE
Add support for BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC use

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ steps:
   - label: "Pipeline upload"
     command: "buildkite-agent pipeline upload"
     plugins:
-      - sparse-checkout#v1.4.0:
+      - sparse-checkout#v1.5.0:
           paths:
             - .buildkite
 ```
@@ -65,7 +65,7 @@ steps:
   - label: "Pipeline upload with clean checkout"
     command: "buildkite-agent pipeline upload"
     plugins:
-      - sparse-checkout#v1.4.0:
+      - sparse-checkout#v1.5.0:
           paths:
             - .buildkite
           clean_checkout: true

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -98,13 +98,24 @@ fi
 
 FETCH_FLAGS+=(--depth 1 origin)
 
-if [[ ${BUILDKITE_COMMIT} = "HEAD" ]]; then
+# Determine if we should use the pull request merge refspec
+USE_MERGE_REFSPEC="false"
+if [[ "${BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC:-false}" = "true" ]] \
+  && [[ -n "${BUILDKITE_PULL_REQUEST:-}" ]] \
+  && [[ "${BUILDKITE_PULL_REQUEST}" != "false" ]]; then
+  USE_MERGE_REFSPEC="true"
+  FETCH_FLAGS+=("refs/pull/${BUILDKITE_PULL_REQUEST}/merge")
+elif [[ ${BUILDKITE_COMMIT} = "HEAD" ]]; then
   FETCH_FLAGS+=("${BUILDKITE_BRANCH}")
 else
   FETCH_FLAGS+=("${BUILDKITE_COMMIT}")
 fi
 
-log_info "Fetching ${BUILDKITE_COMMIT} from origin"
+if [[ "${USE_MERGE_REFSPEC}" = "true" ]]; then
+  log_info "Fetching merge ref for PR #${BUILDKITE_PULL_REQUEST} from origin"
+else
+  log_info "Fetching ${BUILDKITE_COMMIT} from origin"
+fi
 if ! git fetch "${FETCH_FLAGS[@]}"; then
   log_error "Failed to fetch ${BUILDKITE_COMMIT} from origin"
   exit 1
@@ -117,8 +128,12 @@ if ! git sparse-checkout set ${NO_CONE_PARAM:+--no-cone} "${CHECKOUT_PATHS[@]}";
   exit 1
 fi
 
-log_info "Checking out ${BUILDKITE_COMMIT}"
-if [[ ${BUILDKITE_COMMIT} = "HEAD" ]]; then
+if [[ "${USE_MERGE_REFSPEC}" = "true" ]]; then
+  log_info "Checking out merge ref for PR #${BUILDKITE_PULL_REQUEST}"
+else
+  log_info "Checking out ${BUILDKITE_COMMIT}"
+fi
+if [[ "${USE_MERGE_REFSPEC}" = "true" ]] || [[ ${BUILDKITE_COMMIT} = "HEAD" ]]; then
   if ! git checkout FETCH_HEAD; then
     log_error "Failed to checkout FETCH_HEAD"
     exit 1

--- a/tests/checkout.bats
+++ b/tests/checkout.bats
@@ -143,6 +143,90 @@ setup() {
   unstub git
 }
 
+@test "Fetches pull request merge refspec when BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC is true" {
+  export BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC="true"
+  export BUILDKITE_PULL_REQUEST="123"
+  export BUILDKITE_COMMIT="HEAD"
+
+  stub ssh-keyscan "* : echo 'keyscan'"
+  stub git "clean * : echo 'git clean'"
+  stub git "fetch --depth 1 origin refs/pull/123/merge : echo 'git fetch merge refspec'"
+  stub git "sparse-checkout set * * : echo 'git sparse-checkout'"
+  stub git "checkout FETCH_HEAD : echo 'checkout fetch_head'"
+
+  run "$PWD"/hooks/checkout
+
+  assert_success
+  assert_output --partial 'git fetch merge refspec'
+  assert_output --partial 'checkout fetch_head'
+
+  unstub ssh-keyscan
+  unstub git
+}
+
+@test "Fetches pull request merge refspec with known commit" {
+  export BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC="true"
+  export BUILDKITE_PULL_REQUEST="456"
+  export BUILDKITE_COMMIT="abc123"
+
+  stub ssh-keyscan "* : echo 'keyscan'"
+  stub git "clean * : echo 'git clean'"
+  stub git "fetch --depth 1 origin refs/pull/456/merge : echo 'git fetch merge refspec'"
+  stub git "sparse-checkout set * * : echo 'git sparse-checkout'"
+  stub git "checkout FETCH_HEAD : echo 'checkout fetch_head'"
+
+  run "$PWD"/hooks/checkout
+
+  assert_success
+  assert_output --partial 'git fetch merge refspec'
+  assert_output --partial 'checkout fetch_head'
+
+  unstub ssh-keyscan
+  unstub git
+}
+
+@test "Does not use merge refspec when BUILDKITE_PULL_REQUEST is false" {
+  export BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC="true"
+  export BUILDKITE_PULL_REQUEST="false"
+  export BUILDKITE_COMMIT="abc123"
+
+  stub ssh-keyscan "* : echo 'keyscan'"
+  stub git "clean * : echo 'git clean'"
+  stub git "fetch --depth 1 origin abc123 : echo 'git fetch commit'"
+  stub git "sparse-checkout set * * : echo 'git sparse-checkout'"
+  stub git "checkout abc123 : echo 'checkout commit'"
+
+  run "$PWD"/hooks/checkout
+
+  assert_success
+  assert_output --partial 'git fetch commit'
+  assert_output --partial 'checkout commit'
+
+  unstub ssh-keyscan
+  unstub git
+}
+
+@test "Does not use merge refspec when flag is not set" {
+  export BUILDKITE_PULL_REQUEST="123"
+  export BUILDKITE_COMMIT="abc123"
+  unset BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC
+
+  stub ssh-keyscan "* : echo 'keyscan'"
+  stub git "clean * : echo 'git clean'"
+  stub git "fetch --depth 1 origin abc123 : echo 'git fetch commit'"
+  stub git "sparse-checkout set * * : echo 'git sparse-checkout'"
+  stub git "checkout abc123 : echo 'checkout commit'"
+
+  run "$PWD"/hooks/checkout
+
+  assert_success
+  assert_output --partial 'git fetch commit'
+  assert_output --partial 'checkout commit'
+
+  unstub ssh-keyscan
+  unstub git
+}
+
 @test "Clean checkout handles repository without HEAD gracefully" {
   export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEAN_CHECKOUT="true"
 


### PR DESCRIPTION
## Description

Currently the plugin doesn't support `BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC`, which means that the use of that feature will be ignored due to the plugin's checkout hook being used.

This adds support to the plugin where that flag is in use, but falls back to existing function when it isn't.
