### PR TITLE
Add opt-in cleanup_worktree_config to fix sparse state leaking between jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ steps:
   - label: "Pipeline upload"
     command: "buildkite-agent pipeline upload"
     plugins:
-      - sparse-checkout#v1.5.0:
+      - sparse-checkout#v1.6.0:
           paths:
             - .buildkite
 ```
@@ -90,7 +90,7 @@ steps:
   - label: "Build with full history"
     command: "make changelog"
     plugins:
-      - sparse-checkout#v1.5.0:
+      - sparse-checkout#v1.6.0:
           paths:
             - src
             - .buildkite
@@ -107,7 +107,7 @@ steps:
   - label: "Pipeline upload with clean checkout"
     command: "buildkite-agent pipeline upload"
     plugins:
-      - sparse-checkout#v1.5.0:
+      - sparse-checkout#v1.6.0:
           paths:
             - .buildkite
           clean_checkout: true
@@ -122,7 +122,7 @@ steps:
   - label: "Sparse build"
     command: "make build"
     plugins:
-      - sparse-checkout#v1.5.0:
+      - sparse-checkout#v1.6.0:
           paths:
             - src
           cleanup_worktree_config: true

--- a/README.md
+++ b/README.md
@@ -38,6 +38,23 @@ Whether to perform aggressive repository cleanup before checkout. This option ha
 
 Use this option for pipeline upload jobs that don't need to preserve local changes.
 
+#### `cleanup_worktree_config` ('true' or 'false')
+
+Remove the sparse-checkout worktree config after checkout completes, so that subsequent jobs on the same agent that do **not** use sparse checkout are not affected.
+
+When `git sparse-checkout` runs, it writes `.git/config.worktree` and sets `extensions.worktreeConfig`, `core.sparseCheckout`, and `core.sparseCheckoutCone` in git config. On agents with persistent build directories, this state persists across jobs — causing subsequent non-sparse jobs to silently inherit the sparse paths and fail to find files outside them.
+
+Enabling this option runs cleanup in two places:
+
+- **`pre-checkout`**: clears stale sparse config at the start of each run, before the new checkout begins. Handles interrupted jobs where post-checkout never fired.
+- **`post-checkout`**: clears sparse config after the checkout completes, so the next job on the same directory starts clean.
+
+The cleanup removes `.git/config.worktree` and unsets `extensions.worktreeConfig`, `core.sparseCheckout`, and `core.sparseCheckoutCone`. The working tree files are left intact. This deliberately avoids `git sparse-checkout disable`, which re-materialises the full working tree (expensive on large monorepos).
+
+This can also be enabled without modifying individual pipeline configs by setting `SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG=true` as an agent environment variable — useful for enforcing the behaviour fleet-wide.
+
+**Recommended for:** shared agent fleets with persistent build directories where sparse and non-sparse pipelines may run on the same agent.
+
 #### `verbose` ('true' or 'false')
 
 Enable verbose logging with bash execution tracing (`set -x`). This shows each command being executed and can help debug issues with ssh-keyscan, git operations, or other checkout problems. When enabled, you'll see detailed output including command arguments and any error messages from underlying tools.
@@ -95,6 +112,23 @@ steps:
             - .buildkite
           clean_checkout: true
 ```
+
+### Cleaning up worktree config for shared agent fleets
+
+On agents with persistent build directories, sparse-checkout leaves behind git config state that causes subsequent non-sparse jobs to silently inherit the sparse paths and fail. Enable `cleanup_worktree_config` to clean this up before and after each sparse checkout:
+
+```yaml
+steps:
+  - label: "Sparse build"
+    command: "make build"
+    plugins:
+      - sparse-checkout#v1.5.0:
+          paths:
+            - src
+          cleanup_worktree_config: true
+```
+
+The plugin will clean up stale sparse config in `pre-checkout` (protecting the current run from a previous interrupted job) and again in `post-checkout` (protecting the next run from our own sparse state).
 
 ## Testing
 

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -16,16 +16,6 @@ VERBOSE_OPTION="$(plugin_read_config VERBOSE "false")"
 [[ "${VERBOSE_OPTION}" = "true" ]] && set -x
 
 UNSHALLOW_OPTION="$(plugin_read_config POST_CHECKOUT_UNSHALLOW "false")"
-CLEANUP_WORKTREE_CONFIG_OPTION="$(plugin_read_config CLEANUP_WORKTREE_CONFIG "false")"
-if [[ "${SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG:-}" = "true" ]]; then
-  CLEANUP_WORKTREE_CONFIG_OPTION="true"
-fi
-
-# Clean up sparse-checkout config after our checkout so that subsequent non-sparse jobs
-# on the same agent directory are not affected.
-if [[ "${CLEANUP_WORKTREE_CONFIG_OPTION}" = "true" ]]; then
-  cleanup_sparse_checkout_config
-fi
 
 if [[ "${UNSHALLOW_OPTION}" = "true" ]]; then
   if [[ "$(git rev-parse --is-shallow-repository)" = "true" ]]; then

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -15,27 +15,13 @@ setup_error_trap
 VERBOSE_OPTION="$(plugin_read_config VERBOSE "false")"
 [[ "${VERBOSE_OPTION}" = "true" ]] && set -x
 
-UNSHALLOW_OPTION="$(plugin_read_config POST_CHECKOUT_UNSHALLOW "false")"
 CLEANUP_WORKTREE_CONFIG_OPTION="$(plugin_read_config CLEANUP_WORKTREE_CONFIG "false")"
 if [[ "${SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG:-}" = "true" ]]; then
   CLEANUP_WORKTREE_CONFIG_OPTION="true"
 fi
 
-# Clean up sparse-checkout config after our checkout so that subsequent non-sparse jobs
-# on the same agent directory are not affected.
+# Clean up any stale sparse-checkout config left by a previous run (including
+# interrupted jobs where post-checkout never fired) before we start our own checkout.
 if [[ "${CLEANUP_WORKTREE_CONFIG_OPTION}" = "true" ]]; then
   cleanup_sparse_checkout_config
-fi
-
-if [[ "${UNSHALLOW_OPTION}" = "true" ]]; then
-  if [[ "$(git rev-parse --is-shallow-repository)" = "true" ]]; then
-    log_info "Unshallowing repository"
-    if ! git fetch --unshallow origin; then
-      log_error "Failed to unshallow repository"
-      exit 1
-    fi
-    log_success "Repository unshallowed successfully"
-  else
-    log_info "Repository is not shallow, skipping unshallow"
-  fi
 fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -20,8 +20,8 @@ if [[ "${SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG:-}" = "true" ]]; then
   CLEANUP_WORKTREE_CONFIG_OPTION="true"
 fi
 
-# Clean up any stale sparse-checkout config left by a previous run (including
-# interrupted jobs where pre-exit never fired) before we start our own checkout.
+# Clean up sparse-checkout config before the job exits so that subsequent non-sparse
+# jobs on the same agent directory are not affected.
 if [[ "${CLEANUP_WORKTREE_CONFIG_OPTION}" = "true" ]]; then
   cleanup_sparse_checkout_config
 fi

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -174,6 +174,34 @@ string_strip_suffix() {
 }
 
 # ============================================================================
+# Sparse checkout utilities
+# ============================================================================
+
+# Cleans up sparse-checkout config left behind by git sparse-checkout set.
+# Removes .git/config.worktree and unsets the three related config keys so that
+# subsequent non-sparse jobs on the same agent directory are not affected.
+#
+# Deliberately avoids `git sparse-checkout disable` which re-materialises all
+# files in the working tree (expensive on large monorepos).
+#
+# Covers both modern git (extensions.worktreeConfig + .git/config.worktree) and
+# older git that writes core.sparseCheckout directly into .git/config.
+cleanup_sparse_checkout_config() {
+  if [[ ! -d .git ]]; then
+    log_info "No .git directory found, skipping sparse-checkout config cleanup"
+    return 0
+  fi
+  log_info "Cleaning up sparse-checkout config"
+  # Unset the extension flag first so git does not look for the worktree config
+  # file during subsequent config operations.
+  git config --unset extensions.worktreeConfig 2>/dev/null || true
+  rm -f .git/config.worktree
+  git config --unset core.sparseCheckout 2>/dev/null || true
+  git config --unset core.sparseCheckoutCone 2>/dev/null || true
+  log_success "Sparse-checkout config cleaned up"
+}
+
+# ============================================================================
 # File utilities
 # ============================================================================
 

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -177,9 +177,10 @@ string_strip_suffix() {
 # Sparse checkout utilities
 # ============================================================================
 
-# Cleans up sparse-checkout config left behind by git sparse-checkout set.
-# Removes .git/config.worktree and unsets the three related config keys so that
-# subsequent non-sparse jobs on the same agent directory are not affected.
+# Cleans up sparse-checkout state left behind by git sparse-checkout set.
+# Removes .git/config.worktree, unsets the three related config keys, and clears
+# per-file skip-worktree bits from the index so that subsequent non-sparse jobs
+# on the same agent directory are not affected.
 #
 # Deliberately avoids `git sparse-checkout disable` which re-materialises all
 # files in the working tree (expensive on large monorepos).
@@ -192,6 +193,11 @@ cleanup_sparse_checkout_config() {
     return 0
   fi
   log_info "Cleaning up sparse-checkout config"
+  # Clear skip-worktree bits from the index before touching config so that
+  # subsequent non-sparse jobs see all files. These bits are set by
+  # `git sparse-checkout set` and persist independently of config entries.
+  # Using update-index avoids materialising files to disk (unlike disable).
+  git ls-files -t 2>/dev/null | awk '/^S /{print substr($0, 3)}' | xargs git update-index --no-skip-worktree -- 2>/dev/null || true
   # Unset the extension flag first so git does not look for the worktree config
   # file during subsequent config operations.
   git config --unset extensions.worktreeConfig 2>/dev/null || true

--- a/plugin.yml
+++ b/plugin.yml
@@ -16,6 +16,9 @@ configuration:
     clean_checkout:
       type: boolean
       default: false
+    cleanup_worktree_config:
+      type: boolean
+      default: false
     verbose:
       type: boolean
       default: false

--- a/tests/post-checkout.bats
+++ b/tests/post-checkout.bats
@@ -7,9 +7,6 @@ setup() {
 
 teardown() {
   cd "$HOOK_DIR" 2>/dev/null || true
-  if [[ -n "$WORK_DIR" && -d "$WORK_DIR" ]]; then
-    rm -rf "$WORK_DIR"
-  fi
   unstub git 2>/dev/null || true
 }
 
@@ -42,85 +39,6 @@ teardown() {
 
   assert_success
   refute_output --partial 'Unshallowing repository'
-}
-
-@test "Cleanup worktree config enabled - removes config.worktree and unsets all sparse config keys" {
-  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
-
-  WORK_DIR="$(mktemp -d)"
-  mkdir -p "$WORK_DIR/.git"
-  echo '[core]' > "$WORK_DIR/.git/config.worktree"
-
-  stub git \
-    "config --unset extensions.worktreeConfig : true" \
-    "config --unset core.sparseCheckout : true" \
-    "config --unset core.sparseCheckoutCone : true"
-
-  cd "$WORK_DIR"
-  run "$HOOK_DIR/hooks/post-checkout"
-
-  assert_success
-  assert_output --partial 'Cleaning up sparse-checkout config'
-  assert_output --partial 'Sparse-checkout config cleaned up'
-  [[ ! -f "$WORK_DIR/.git/config.worktree" ]]
-}
-
-@test "Cleanup worktree config enabled - succeeds even when no prior sparse config exists" {
-  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
-
-  WORK_DIR="$(mktemp -d)"
-  mkdir -p "$WORK_DIR/.git"
-
-  stub git \
-    "config --unset extensions.worktreeConfig : true" \
-    "config --unset core.sparseCheckout : true" \
-    "config --unset core.sparseCheckoutCone : true"
-
-  cd "$WORK_DIR"
-  run "$HOOK_DIR/hooks/post-checkout"
-
-  assert_success
-  assert_output --partial 'Cleaning up sparse-checkout config'
-  assert_output --partial 'Sparse-checkout config cleaned up'
-}
-
-@test "Cleanup worktree config enabled - skips when no .git directory" {
-  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
-
-  WORK_DIR="$(mktemp -d)"
-
-  cd "$WORK_DIR"
-  run "$HOOK_DIR/hooks/post-checkout"
-
-  assert_success
-  assert_output --partial 'No .git directory found, skipping sparse-checkout config cleanup'
-  refute_output --partial 'Cleaning up sparse-checkout config'
-}
-
-@test "Cleanup worktree config enabled via SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG env var" {
-  unset BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG
-  export SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
-
-  WORK_DIR="$(mktemp -d)"
-  mkdir -p "$WORK_DIR/.git"
-
-  stub git \
-    "config --unset extensions.worktreeConfig : true" \
-    "config --unset core.sparseCheckout : true" \
-    "config --unset core.sparseCheckoutCone : true"
-
-  cd "$WORK_DIR"
-  run "$HOOK_DIR/hooks/post-checkout"
-
-  assert_success
-  assert_output --partial 'Cleaning up sparse-checkout config'
-}
-
-@test "Cleanup worktree config not configured - no cleanup runs" {
-  run "$HOOK_DIR"/hooks/post-checkout
-
-  assert_success
-  refute_output --partial 'sparse-checkout config'
 }
 
 @test "Unshallow enabled but fetch fails exits with error" {

--- a/tests/post-checkout.bats
+++ b/tests/post-checkout.bats
@@ -5,6 +5,14 @@ setup() {
   HOOK_DIR="$PWD"
 }
 
+teardown() {
+  cd "$HOOK_DIR" 2>/dev/null || true
+  if [[ -n "$WORK_DIR" && -d "$WORK_DIR" ]]; then
+    rm -rf "$WORK_DIR"
+  fi
+  unstub git 2>/dev/null || true
+}
+
 @test "Unshallow enabled and repo is shallow runs git fetch --unshallow" {
   export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_POST_CHECKOUT_UNSHALLOW="true"
 
@@ -16,8 +24,6 @@ setup() {
   assert_success
   assert_output --partial 'Unshallowing repository'
   assert_output --partial 'Repository unshallowed successfully'
-
-  unstub git
 }
 
 @test "Unshallow enabled and repo is not shallow skips unshallow" {
@@ -29,8 +35,6 @@ setup() {
 
   assert_success
   assert_output --partial 'Repository is not shallow, skipping unshallow'
-
-  unstub git
 }
 
 @test "Unshallow not configured skips post-checkout operations" {
@@ -43,92 +47,73 @@ setup() {
 @test "Cleanup worktree config enabled - removes config.worktree and unsets all sparse config keys" {
   export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
 
-  local work_dir
-  work_dir="$(mktemp -d)"
-  mkdir -p "$work_dir/.git"
-  echo '[core]' > "$work_dir/.git/config.worktree"
+  WORK_DIR="$(mktemp -d)"
+  mkdir -p "$WORK_DIR/.git"
+  echo '[core]' > "$WORK_DIR/.git/config.worktree"
 
   stub git \
     "config --unset extensions.worktreeConfig : true" \
     "config --unset core.sparseCheckout : true" \
     "config --unset core.sparseCheckoutCone : true"
 
-  cd "$work_dir"
+  cd "$WORK_DIR"
   run "$HOOK_DIR/hooks/post-checkout"
-  cd "$HOOK_DIR"
 
   assert_success
   assert_output --partial 'Cleaning up sparse-checkout config'
   assert_output --partial 'Sparse-checkout config cleaned up'
-  [[ ! -f "$work_dir/.git/config.worktree" ]]
-
-  unstub git
-  rm -rf "$work_dir"
+  [[ ! -f "$WORK_DIR/.git/config.worktree" ]]
 }
 
 @test "Cleanup worktree config enabled - succeeds even when no prior sparse config exists" {
   export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
 
-  local work_dir
-  work_dir="$(mktemp -d)"
-  mkdir -p "$work_dir/.git"
+  WORK_DIR="$(mktemp -d)"
+  mkdir -p "$WORK_DIR/.git"
 
   stub git \
     "config --unset extensions.worktreeConfig : true" \
     "config --unset core.sparseCheckout : true" \
     "config --unset core.sparseCheckoutCone : true"
 
-  cd "$work_dir"
+  cd "$WORK_DIR"
   run "$HOOK_DIR/hooks/post-checkout"
-  cd "$HOOK_DIR"
 
   assert_success
   assert_output --partial 'Cleaning up sparse-checkout config'
   assert_output --partial 'Sparse-checkout config cleaned up'
-
-  unstub git
-  rm -rf "$work_dir"
 }
 
 @test "Cleanup worktree config enabled - skips when no .git directory" {
   export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
 
-  local work_dir
-  work_dir="$(mktemp -d)"
+  WORK_DIR="$(mktemp -d)"
 
-  cd "$work_dir"
+  cd "$WORK_DIR"
   run "$HOOK_DIR/hooks/post-checkout"
-  cd "$HOOK_DIR"
 
   assert_success
   assert_output --partial 'No .git directory found, skipping sparse-checkout config cleanup'
   refute_output --partial 'Cleaning up sparse-checkout config'
-
-  rm -rf "$work_dir"
 }
 
 @test "Cleanup worktree config enabled via SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG env var" {
   unset BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG
   export SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
 
-  local work_dir
-  work_dir="$(mktemp -d)"
-  mkdir -p "$work_dir/.git"
+  WORK_DIR="$(mktemp -d)"
+  mkdir -p "$WORK_DIR/.git"
 
   stub git \
     "config --unset extensions.worktreeConfig : true" \
     "config --unset core.sparseCheckout : true" \
     "config --unset core.sparseCheckoutCone : true"
 
-  cd "$work_dir"
+  cd "$WORK_DIR"
   run "$HOOK_DIR/hooks/post-checkout"
-  cd "$HOOK_DIR"
 
   assert_success
   assert_output --partial 'Cleaning up sparse-checkout config'
-
-  unstub git
-  rm -rf "$work_dir"
 }
 
 @test "Cleanup worktree config not configured - no cleanup runs" {
@@ -148,6 +133,4 @@ setup() {
 
   assert_failure
   assert_output --partial 'Failed to unshallow repository'
-
-  unstub git
 }

--- a/tests/pre-checkout.bats
+++ b/tests/pre-checkout.bats
@@ -5,42 +5,7 @@ setup() {
   HOOK_DIR="$PWD"
 }
 
-@test "Unshallow enabled and repo is shallow runs git fetch --unshallow" {
-  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_POST_CHECKOUT_UNSHALLOW="true"
-
-  stub git "rev-parse --is-shallow-repository : echo 'true'" \
-           "fetch --unshallow origin : echo 'git fetch unshallow'"
-
-  run "$HOOK_DIR"/hooks/post-checkout
-
-  assert_success
-  assert_output --partial 'Unshallowing repository'
-  assert_output --partial 'Repository unshallowed successfully'
-
-  unstub git
-}
-
-@test "Unshallow enabled and repo is not shallow skips unshallow" {
-  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_POST_CHECKOUT_UNSHALLOW="true"
-
-  stub git "rev-parse --is-shallow-repository : echo 'false'"
-
-  run "$HOOK_DIR"/hooks/post-checkout
-
-  assert_success
-  assert_output --partial 'Repository is not shallow, skipping unshallow'
-
-  unstub git
-}
-
-@test "Unshallow not configured skips post-checkout operations" {
-  run "$HOOK_DIR"/hooks/post-checkout
-
-  assert_success
-  refute_output --partial 'Unshallowing repository'
-}
-
-@test "Cleanup worktree config enabled - removes config.worktree and unsets all sparse config keys" {
+@test "Cleanup worktree config enabled - cleans up stale sparse config before checkout" {
   export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
 
   local work_dir
@@ -54,7 +19,7 @@ setup() {
     "config --unset core.sparseCheckoutCone : true"
 
   cd "$work_dir"
-  run "$HOOK_DIR/hooks/post-checkout"
+  run "$HOOK_DIR/hooks/pre-checkout"
   cd "$HOOK_DIR"
 
   assert_success
@@ -79,7 +44,7 @@ setup() {
     "config --unset core.sparseCheckoutCone : true"
 
   cd "$work_dir"
-  run "$HOOK_DIR/hooks/post-checkout"
+  run "$HOOK_DIR/hooks/pre-checkout"
   cd "$HOOK_DIR"
 
   assert_success
@@ -90,14 +55,14 @@ setup() {
   rm -rf "$work_dir"
 }
 
-@test "Cleanup worktree config enabled - skips when no .git directory" {
+@test "Cleanup worktree config enabled - skips when no .git directory exists yet" {
   export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
 
   local work_dir
   work_dir="$(mktemp -d)"
 
   cd "$work_dir"
-  run "$HOOK_DIR/hooks/post-checkout"
+  run "$HOOK_DIR/hooks/pre-checkout"
   cd "$HOOK_DIR"
 
   assert_success
@@ -121,7 +86,7 @@ setup() {
     "config --unset core.sparseCheckoutCone : true"
 
   cd "$work_dir"
-  run "$HOOK_DIR/hooks/post-checkout"
+  run "$HOOK_DIR/hooks/pre-checkout"
   cd "$HOOK_DIR"
 
   assert_success
@@ -131,23 +96,9 @@ setup() {
   rm -rf "$work_dir"
 }
 
-@test "Cleanup worktree config not configured - no cleanup runs" {
-  run "$HOOK_DIR"/hooks/post-checkout
+@test "Cleanup worktree config not configured - does nothing" {
+  run "$HOOK_DIR/hooks/pre-checkout"
 
   assert_success
   refute_output --partial 'sparse-checkout config'
-}
-
-@test "Unshallow enabled but fetch fails exits with error" {
-  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_POST_CHECKOUT_UNSHALLOW="true"
-
-  stub git "rev-parse --is-shallow-repository : echo 'true'" \
-           "fetch --unshallow origin : exit 1"
-
-  run "$HOOK_DIR"/hooks/post-checkout
-
-  assert_failure
-  assert_output --partial 'Failed to unshallow repository'
-
-  unstub git
 }

--- a/tests/pre-checkout.bats
+++ b/tests/pre-checkout.bats
@@ -5,95 +5,84 @@ setup() {
   HOOK_DIR="$PWD"
 }
 
+teardown() {
+  cd "$HOOK_DIR" 2>/dev/null || true
+  if [[ -n "$WORK_DIR" && -d "$WORK_DIR" ]]; then
+    rm -rf "$WORK_DIR"
+  fi
+  unstub git 2>/dev/null || true
+}
+
 @test "Cleanup worktree config enabled - cleans up stale sparse config before checkout" {
   export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
 
-  local work_dir
-  work_dir="$(mktemp -d)"
-  mkdir -p "$work_dir/.git"
-  echo '[core]' > "$work_dir/.git/config.worktree"
+  WORK_DIR="$(mktemp -d)"
+  mkdir -p "$WORK_DIR/.git"
+  echo '[core]' > "$WORK_DIR/.git/config.worktree"
 
   stub git \
     "config --unset extensions.worktreeConfig : true" \
     "config --unset core.sparseCheckout : true" \
     "config --unset core.sparseCheckoutCone : true"
 
-  cd "$work_dir"
+  cd "$WORK_DIR"
   run "$HOOK_DIR/hooks/pre-checkout"
-  cd "$HOOK_DIR"
 
   assert_success
   assert_output --partial 'Cleaning up sparse-checkout config'
   assert_output --partial 'Sparse-checkout config cleaned up'
-  [[ ! -f "$work_dir/.git/config.worktree" ]]
-
-  unstub git
-  rm -rf "$work_dir"
+  [[ ! -f "$WORK_DIR/.git/config.worktree" ]]
 }
 
 @test "Cleanup worktree config enabled - succeeds even when no prior sparse config exists" {
   export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
 
-  local work_dir
-  work_dir="$(mktemp -d)"
-  mkdir -p "$work_dir/.git"
+  WORK_DIR="$(mktemp -d)"
+  mkdir -p "$WORK_DIR/.git"
 
   stub git \
     "config --unset extensions.worktreeConfig : true" \
     "config --unset core.sparseCheckout : true" \
     "config --unset core.sparseCheckoutCone : true"
 
-  cd "$work_dir"
+  cd "$WORK_DIR"
   run "$HOOK_DIR/hooks/pre-checkout"
-  cd "$HOOK_DIR"
 
   assert_success
   assert_output --partial 'Cleaning up sparse-checkout config'
   assert_output --partial 'Sparse-checkout config cleaned up'
-
-  unstub git
-  rm -rf "$work_dir"
 }
 
 @test "Cleanup worktree config enabled - skips when no .git directory exists yet" {
   export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
 
-  local work_dir
-  work_dir="$(mktemp -d)"
+  WORK_DIR="$(mktemp -d)"
 
-  cd "$work_dir"
+  cd "$WORK_DIR"
   run "$HOOK_DIR/hooks/pre-checkout"
-  cd "$HOOK_DIR"
 
   assert_success
   assert_output --partial 'No .git directory found, skipping sparse-checkout config cleanup'
   refute_output --partial 'Cleaning up sparse-checkout config'
-
-  rm -rf "$work_dir"
 }
 
 @test "Cleanup worktree config enabled via SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG env var" {
   unset BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG
   export SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
 
-  local work_dir
-  work_dir="$(mktemp -d)"
-  mkdir -p "$work_dir/.git"
+  WORK_DIR="$(mktemp -d)"
+  mkdir -p "$WORK_DIR/.git"
 
   stub git \
     "config --unset extensions.worktreeConfig : true" \
     "config --unset core.sparseCheckout : true" \
     "config --unset core.sparseCheckoutCone : true"
 
-  cd "$work_dir"
+  cd "$WORK_DIR"
   run "$HOOK_DIR/hooks/pre-checkout"
-  cd "$HOOK_DIR"
 
   assert_success
   assert_output --partial 'Cleaning up sparse-checkout config'
-
-  unstub git
-  rm -rf "$work_dir"
 }
 
 @test "Cleanup worktree config not configured - does nothing" {

--- a/tests/pre-exit.bats
+++ b/tests/pre-exit.bats
@@ -21,6 +21,7 @@ teardown() {
   echo '[core]' > "$WORK_DIR/.git/config.worktree"
 
   stub git \
+    "ls-files -t : true" \
     "config --unset extensions.worktreeConfig : true" \
     "config --unset core.sparseCheckout : true" \
     "config --unset core.sparseCheckoutCone : true"
@@ -41,6 +42,7 @@ teardown() {
   mkdir -p "$WORK_DIR/.git"
 
   stub git \
+    "ls-files -t : true" \
     "config --unset extensions.worktreeConfig : true" \
     "config --unset core.sparseCheckout : true" \
     "config --unset core.sparseCheckoutCone : true"
@@ -74,6 +76,7 @@ teardown() {
   mkdir -p "$WORK_DIR/.git"
 
   stub git \
+    "ls-files -t : true" \
     "config --unset extensions.worktreeConfig : true" \
     "config --unset core.sparseCheckout : true" \
     "config --unset core.sparseCheckoutCone : true"
@@ -83,6 +86,26 @@ teardown() {
 
   assert_success
   assert_output --partial 'Cleaning up sparse-checkout config'
+}
+
+@test "Cleanup worktree config enabled - clears skip-worktree bits from index" {
+  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
+
+  WORK_DIR="$(mktemp -d)"
+  mkdir -p "$WORK_DIR/.git"
+
+  stub git \
+    "ls-files -t : echo 'S lib/excluded.rb'" \
+    "update-index --no-skip-worktree -- lib/excluded.rb : true" \
+    "config --unset extensions.worktreeConfig : true" \
+    "config --unset core.sparseCheckout : true" \
+    "config --unset core.sparseCheckoutCone : true"
+
+  cd "$WORK_DIR"
+  run "$HOOK_DIR/hooks/pre-exit"
+
+  assert_success
+  assert_output --partial 'Sparse-checkout config cleaned up'
 }
 
 @test "Cleanup worktree config not configured - no cleanup runs" {

--- a/tests/pre-exit.bats
+++ b/tests/pre-exit.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+
+setup() {
+  load "${BATS_PLUGIN_PATH}/load.bash"
+  HOOK_DIR="$PWD"
+}
+
+teardown() {
+  cd "$HOOK_DIR" 2>/dev/null || true
+  if [[ -n "$WORK_DIR" && -d "$WORK_DIR" ]]; then
+    rm -rf "$WORK_DIR"
+  fi
+  unstub git 2>/dev/null || true
+}
+
+@test "Cleanup worktree config enabled - removes config.worktree and unsets all sparse config keys" {
+  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
+
+  WORK_DIR="$(mktemp -d)"
+  mkdir -p "$WORK_DIR/.git"
+  echo '[core]' > "$WORK_DIR/.git/config.worktree"
+
+  stub git \
+    "config --unset extensions.worktreeConfig : true" \
+    "config --unset core.sparseCheckout : true" \
+    "config --unset core.sparseCheckoutCone : true"
+
+  cd "$WORK_DIR"
+  run "$HOOK_DIR/hooks/pre-exit"
+
+  assert_success
+  assert_output --partial 'Cleaning up sparse-checkout config'
+  assert_output --partial 'Sparse-checkout config cleaned up'
+  [[ ! -f "$WORK_DIR/.git/config.worktree" ]]
+}
+
+@test "Cleanup worktree config enabled - succeeds even when no prior sparse config exists" {
+  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
+
+  WORK_DIR="$(mktemp -d)"
+  mkdir -p "$WORK_DIR/.git"
+
+  stub git \
+    "config --unset extensions.worktreeConfig : true" \
+    "config --unset core.sparseCheckout : true" \
+    "config --unset core.sparseCheckoutCone : true"
+
+  cd "$WORK_DIR"
+  run "$HOOK_DIR/hooks/pre-exit"
+
+  assert_success
+  assert_output --partial 'Cleaning up sparse-checkout config'
+  assert_output --partial 'Sparse-checkout config cleaned up'
+}
+
+@test "Cleanup worktree config enabled - skips when no .git directory" {
+  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
+
+  WORK_DIR="$(mktemp -d)"
+
+  cd "$WORK_DIR"
+  run "$HOOK_DIR/hooks/pre-exit"
+
+  assert_success
+  assert_output --partial 'No .git directory found, skipping sparse-checkout config cleanup'
+  refute_output --partial 'Cleaning up sparse-checkout config'
+}
+
+@test "Cleanup worktree config enabled via SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG env var" {
+  unset BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG
+  export SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
+
+  WORK_DIR="$(mktemp -d)"
+  mkdir -p "$WORK_DIR/.git"
+
+  stub git \
+    "config --unset extensions.worktreeConfig : true" \
+    "config --unset core.sparseCheckout : true" \
+    "config --unset core.sparseCheckoutCone : true"
+
+  cd "$WORK_DIR"
+  run "$HOOK_DIR/hooks/pre-exit"
+
+  assert_success
+  assert_output --partial 'Cleaning up sparse-checkout config'
+}
+
+@test "Cleanup worktree config not configured - no cleanup runs" {
+  run "$HOOK_DIR/hooks/pre-exit"
+
+  assert_success
+  refute_output --partial 'sparse-checkout config'
+}


### PR DESCRIPTION
## Problem

On agents with persistent build directories, `git sparse-checkout set` leaves behind git config state that persists across jobs:

- `.git/config.worktree` — worktree-specific config (modern git with `extensions.worktreeConfig`)
- `extensions.worktreeConfig` in `.git/config`
- `core.sparseCheckout` in `.git/config`
- `core.sparseCheckoutCone` in `.git/config`

Subsequent non-sparse jobs on the same agent directory silently inherit these sparse paths and fail to find files outside them. I hit this running ~100 agents in a shared default fleet with ~50 pipelines, some sparse and some not.

`git sparse-checkout disable` would fix the config but re-materialises the full working tree — on our monorepo this added ~20s per build.

## Solution

Adds an opt-in `cleanup_worktree_config` flag (also readable from the `SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG` environment variable for fleet-wide enforcement without modifying individual pipelines).

When enabled, cleanup runs at two points in the hook lifecycle:

- **`pre-exit`** — clears sparse config right before the job exits, always, regardless of job success or failure
- **`pre-checkout`** — clears any stale sparse config left by a previous run before the new checkout begins, as a safety net for interrupted jobs where `pre-exit` never fired

The cleanup unsets `extensions.worktreeConfig` first (so git stops treating the repo as worktree-config-enabled), then removes `.git/config.worktree`, then unsets `core.sparseCheckout` and `core.sparseCheckoutCone`. Working tree files are left intact.

## Usage

```yaml
steps:
  - label: "Sparse build"
    command: "make build"
    plugins:
      - sparse-checkout#v1.5.0:
          paths:
            - src
          cleanup_worktree_config: true
```

Or set `SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG=true` as an agent environment variable to enforce fleet-wide without touching individual pipelines.

## Test plan

- [ ] New `hooks/pre-exit` hook with 5 BATS tests covering: cleanup with existing sparse state, cleanup with no prior state, skip when no `.git` dir, env var activation, unconfigured no-op
- [ ] New `hooks/pre-checkout` hook with matching tests
- [ ] All tests use isolated `mktemp -d` directories to avoid touching the real repo's `.git`
- [ ] Run full test suite: `docker run --rm -ti -v "${PWD}":/plugin buildkite/plugin-tester:latest`
