### PR TITLE
Add retries when pulling the merge refspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ Whether to perform aggressive repository cleanup before checkout. This option ha
 
 Use this option for pipeline upload jobs that don't need to preserve local changes.
 
+When `BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC=true`, the plugin will retry the
+GitHub merge ref checkout if it sees the known "missing merge ref" failure:
+
+- retry after 2 seconds
+- retry after 5 seconds
+- if the merge ref is still unavailable, fall back to the normal non-merge-ref
+  target (`BUILDKITE_BRANCH` when `BUILDKITE_COMMIT=HEAD`, otherwise
+  `BUILDKITE_COMMIT`)
+
+This retry logic only applies to the specific merge-ref-not-ready error. Other
+`git fetch` failures still fail immediately.
+
 #### `verbose` ('true' or 'false')
 
 Enable verbose logging with bash execution tracing (`set -x`). This shows each command being executed and can help debug issues with ssh-keyscan, git operations, or other checkout problems. When enabled, you'll see detailed output including command arguments and any error messages from underlying tools.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Use this option for pipeline upload jobs that don't need to preserve local chang
 
 Enable verbose logging with bash execution tracing (`set -x`). This shows each command being executed and can help debug issues with ssh-keyscan, git operations, or other checkout problems. When enabled, you'll see detailed output including command arguments and any error messages from underlying tools.
 
+#### `merge_ref_retry_attempts` (integer)
+
+How many times to try fetching the GitHub pull-request merge ref (`refs/pull/<n>/merge`) when using merge-ref checkout (see `BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC` below). Defaults to `3`. Between attempts the hook waits 2 seconds after the first failure and 5 seconds after later failures. Set to `0` to skip merge-ref fetch attempts and fall back immediately.
+
 #### `post_checkout` (object)
 
 Options that run after the sparse checkout completes, in the `post-checkout` hook.
@@ -54,13 +58,11 @@ Convert the shallow clone into a full-depth clone by running `git fetch --unshal
 
 ### BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC
 When `BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC=true`, the plugin will retry the
-GitHub merge ref checkout if it sees the known "missing merge ref" failure:
-
-- retry after 2 seconds
-- retry after 5 seconds
-- if the merge ref is still unavailable, fall back to the normal non-merge-ref
-  target (`BUILDKITE_BRANCH` when `BUILDKITE_COMMIT=HEAD`, otherwise
-  `BUILDKITE_COMMIT`)
+GitHub merge ref checkout if it sees the known "missing merge ref" failure, up to
+`merge_ref_retry_attempts` times (default `3`). Between attempts it waits 2 seconds
+after the first failure and 5 seconds after subsequent failures. If the merge ref
+is still unavailable, it falls back to the normal non-merge-ref target
+(`BUILDKITE_BRANCH` when `BUILDKITE_COMMIT=HEAD`, otherwise `BUILDKITE_COMMIT`).
 
 This retry logic only applies to the specific merge-ref-not-ready error. Other
 `git fetch` failures still fail immediately.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,21 @@ Whether to perform aggressive repository cleanup before checkout. This option ha
 
 Use this option for pipeline upload jobs that don't need to preserve local changes.
 
+#### `verbose` ('true' or 'false')
+
+Enable verbose logging with bash execution tracing (`set -x`). This shows each command being executed and can help debug issues with ssh-keyscan, git operations, or other checkout problems. When enabled, you'll see detailed output including command arguments and any error messages from underlying tools.
+
+#### `post_checkout` (object)
+
+Options that run after the sparse checkout completes, in the `post-checkout` hook.
+
+#### `unshallow` ('true' or 'false')
+
+Convert the shallow clone into a full-depth clone by running `git fetch --unshallow origin` after checkout. This is useful when your build requires full git history (for example, changelog generation, `git log`, or `git blame`). If the repository is already unshallow, this step is skipped.
+
+## Environment Variables
+
+### BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC
 When `BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC=true`, the plugin will retry the
 GitHub merge ref checkout if it sees the known "missing merge ref" failure:
 
@@ -50,17 +65,6 @@ GitHub merge ref checkout if it sees the known "missing merge ref" failure:
 This retry logic only applies to the specific merge-ref-not-ready error. Other
 `git fetch` failures still fail immediately.
 
-#### `verbose` ('true' or 'false')
-
-Enable verbose logging with bash execution tracing (`set -x`). This shows each command being executed and can help debug issues with ssh-keyscan, git operations, or other checkout problems. When enabled, you'll see detailed output including command arguments and any error messages from underlying tools.
-
-#### `post_checkout` (object)
-
-Options that run after the sparse checkout completes, in the `post-checkout` hook.
-
-##### `unshallow` ('true' or 'false')
-
-Convert the shallow clone into a full-depth clone by running `git fetch --unshallow origin` after checkout. This is useful when your build requires full git history (for example, changelog generation, `git log`, or `git blame`). If the repository is already unshallow, this step is skipped.
 
 ## Example
 

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -167,11 +167,7 @@ if [[ "${USE_MERGE_REFSPEC}" != "true" ]]; then
   else
     FETCH_FLAGS+=("${BUILDKITE_COMMIT}")
   fi
-fi
 
-if [[ "${USE_MERGE_REFSPEC}" = "true" ]]; then
-  :
-else
   log_info "Fetching ${BUILDKITE_COMMIT} from origin"
   if ! git fetch "${FETCH_FLAGS[@]}"; then
     log_error "Failed to fetch ${BUILDKITE_COMMIT} from origin"
@@ -188,22 +184,18 @@ fi
 
 if [[ "${USE_MERGE_REFSPEC}" = "true" ]]; then
   log_info "Checking out merge ref for PR #${BUILDKITE_PULL_REQUEST}"
+else
+  log_info "Checking out ${BUILDKITE_COMMIT}"
+fi
+if [[ "${USE_MERGE_REFSPEC}" = "true" ]] || [[ ${BUILDKITE_COMMIT} = "HEAD" ]]; then
   if ! git checkout FETCH_HEAD; then
     log_error "Failed to checkout FETCH_HEAD"
     exit 1
   fi
 else
-  log_info "Checking out ${BUILDKITE_COMMIT}"
-  if [[ ${BUILDKITE_COMMIT} = "HEAD" ]]; then
-    if ! git checkout FETCH_HEAD; then
-      log_error "Failed to checkout FETCH_HEAD"
-      exit 1
-    fi
-  else
-    if ! git checkout "${BUILDKITE_COMMIT}"; then
-      log_error "Failed to checkout ${BUILDKITE_COMMIT}"
-      exit 1
-    fi
+  if ! git checkout "${BUILDKITE_COMMIT}"; then
+    log_error "Failed to checkout ${BUILDKITE_COMMIT}"
+    exit 1
   fi
 fi
 log_success "Sparse checkout completed successfully"

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -100,25 +100,113 @@ FETCH_FLAGS+=(--depth 1 origin)
 
 # Determine if we should use the pull request merge refspec
 USE_MERGE_REFSPEC="false"
+FETCH_TARGET=""
+FETCH_TARGET_DESCRIPTION=""
+CHECKOUT_TARGET=""
+CHECKOUT_DESCRIPTION=""
 if [[ "${BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC:-false}" = "true" ]] \
   && [[ -n "${BUILDKITE_PULL_REQUEST:-}" ]] \
   && [[ "${BUILDKITE_PULL_REQUEST}" != "false" ]]; then
   USE_MERGE_REFSPEC="true"
-  FETCH_FLAGS+=("refs/pull/${BUILDKITE_PULL_REQUEST}/merge")
+  FETCH_TARGET="refs/pull/${BUILDKITE_PULL_REQUEST}/merge"
+  FETCH_TARGET_DESCRIPTION="merge ref ${FETCH_TARGET} from origin"
+  CHECKOUT_TARGET="FETCH_HEAD"
+  CHECKOUT_DESCRIPTION="merge ref for PR #${BUILDKITE_PULL_REQUEST}"
 elif [[ ${BUILDKITE_COMMIT} = "HEAD" ]]; then
-  FETCH_FLAGS+=("${BUILDKITE_BRANCH}")
+  FETCH_TARGET="${BUILDKITE_BRANCH}"
+  FETCH_TARGET_DESCRIPTION="branch ${BUILDKITE_BRANCH} from origin"
+  CHECKOUT_TARGET="FETCH_HEAD"
+  CHECKOUT_DESCRIPTION="${BUILDKITE_BRANCH}"
 else
-  FETCH_FLAGS+=("${BUILDKITE_COMMIT}")
+  FETCH_TARGET="${BUILDKITE_COMMIT}"
+  FETCH_TARGET_DESCRIPTION="${BUILDKITE_COMMIT} from origin"
+  CHECKOUT_TARGET="${BUILDKITE_COMMIT}"
+  CHECKOUT_DESCRIPTION="${BUILDKITE_COMMIT}"
 fi
 
+FETCH_OUTPUT=""
+
+run_fetch() {
+  if FETCH_OUTPUT=$(git fetch "${FETCH_FLAGS[@]}" "${FETCH_TARGET}" 2>&1); then
+    [[ -n "${FETCH_OUTPUT}" ]] && printf '%s\n' "${FETCH_OUTPUT}"
+    return 0
+  else
+    local status=$?
+    [[ -n "${FETCH_OUTPUT}" ]] && printf '%s\n' "${FETCH_OUTPUT}" >&2
+    return "${status}"
+  fi
+}
+
+is_missing_merge_ref_error() {
+  local merge_ref="refs/pull/${BUILDKITE_PULL_REQUEST}/merge"
+  [[ "${FETCH_OUTPUT}" == *"couldn't find remote ref ${merge_ref}"* ]] \
+    || [[ "${FETCH_OUTPUT}" == *"not our ref ${merge_ref}"* ]]
+}
+
+log_info "Fetching ${FETCH_TARGET_DESCRIPTION}"
 if [[ "${USE_MERGE_REFSPEC}" = "true" ]]; then
-  log_info "Fetching merge ref for PR #${BUILDKITE_PULL_REQUEST} from origin"
+  if run_fetch; then
+    :
+  else
+    status=$?
+    if ! is_missing_merge_ref_error; then
+      log_error "Failed to fetch ${FETCH_TARGET_DESCRIPTION}"
+      exit "${status}"
+    fi
+
+    log_warning "Merge ref ${FETCH_TARGET} was not available yet; retrying in 2s"
+    sleep 2
+    if run_fetch; then
+      :
+    else
+      status=$?
+      if ! is_missing_merge_ref_error; then
+        log_error "Failed to fetch ${FETCH_TARGET_DESCRIPTION}"
+        exit "${status}"
+      fi
+
+      log_warning "Merge ref ${FETCH_TARGET} was still not available; retrying in 5s"
+      sleep 5
+      if run_fetch; then
+        :
+      else
+        status=$?
+        if ! is_missing_merge_ref_error; then
+          log_error "Failed to fetch ${FETCH_TARGET_DESCRIPTION}"
+          exit "${status}"
+        fi
+
+        if [[ "${BUILDKITE_COMMIT}" = "HEAD" ]]; then
+          log_warning "Merge ref ${FETCH_TARGET} was still unavailable; falling back to branch ${BUILDKITE_BRANCH}"
+          FETCH_TARGET="${BUILDKITE_BRANCH}"
+          FETCH_TARGET_DESCRIPTION="fallback branch ${BUILDKITE_BRANCH} from origin"
+          CHECKOUT_TARGET="FETCH_HEAD"
+          CHECKOUT_DESCRIPTION="${BUILDKITE_BRANCH}"
+        else
+          log_warning "Merge ref ${FETCH_TARGET} was still unavailable; falling back to ${BUILDKITE_COMMIT}"
+          FETCH_TARGET="${BUILDKITE_COMMIT}"
+          FETCH_TARGET_DESCRIPTION="fallback commit ${BUILDKITE_COMMIT} from origin"
+          CHECKOUT_TARGET="${BUILDKITE_COMMIT}"
+          CHECKOUT_DESCRIPTION="${BUILDKITE_COMMIT}"
+        fi
+        USE_MERGE_REFSPEC="false"
+
+        if run_fetch; then
+          :
+        else
+          status=$?
+          log_error "Failed to fetch ${FETCH_TARGET_DESCRIPTION}"
+          exit "${status}"
+        fi
+      fi
+    fi
+  fi
+elif run_fetch; then
+  :
 else
-  log_info "Fetching ${BUILDKITE_COMMIT} from origin"
-fi
-if ! git fetch "${FETCH_FLAGS[@]}"; then
-  log_error "Failed to fetch ${BUILDKITE_COMMIT} from origin"
-  exit 1
+  status=$?
+  log_error "Failed to fetch ${FETCH_TARGET_DESCRIPTION}"
+  exit "${status}"
 fi
 log_success "Fetch completed successfully"
 
@@ -128,21 +216,15 @@ if ! git sparse-checkout set ${NO_CONE_PARAM:+--no-cone} "${CHECKOUT_PATHS[@]}";
   exit 1
 fi
 
-if [[ "${USE_MERGE_REFSPEC}" = "true" ]]; then
-  log_info "Checking out merge ref for PR #${BUILDKITE_PULL_REQUEST}"
-else
-  log_info "Checking out ${BUILDKITE_COMMIT}"
-fi
-if [[ "${USE_MERGE_REFSPEC}" = "true" ]] || [[ ${BUILDKITE_COMMIT} = "HEAD" ]]; then
+log_info "Checking out ${CHECKOUT_DESCRIPTION}"
+if [[ "${CHECKOUT_TARGET}" = "FETCH_HEAD" ]]; then
   if ! git checkout FETCH_HEAD; then
     log_error "Failed to checkout FETCH_HEAD"
     exit 1
   fi
-else
-  if ! git checkout "${BUILDKITE_COMMIT}"; then
-    log_error "Failed to checkout ${BUILDKITE_COMMIT}"
-    exit 1
-  fi
+elif ! git checkout "${CHECKOUT_TARGET}"; then
+  log_error "Failed to checkout ${CHECKOUT_TARGET}"
+  exit 1
 fi
 
 log_success "Sparse checkout completed successfully"

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -30,12 +30,7 @@ fi
 SKIP_SSH_KEYSCAN_OPTION="$(plugin_read_config SKIP_SSH_KEYSCAN "false")"
 CLEAN_CHECKOUT_OPTION="$(plugin_read_config CLEAN_CHECKOUT "false")"
 
-MERGE_REF_RETRY_ATTEMPTS_RAW="$(plugin_read_config MERGE_REF_RETRY_ATTEMPTS "3")"
-if [[ "${MERGE_REF_RETRY_ATTEMPTS_RAW}" =~ ^[0-9]+$ ]]; then
-  MERGE_REF_RETRY_ATTEMPTS="${MERGE_REF_RETRY_ATTEMPTS_RAW}"
-else
-  MERGE_REF_RETRY_ATTEMPTS=3
-fi
+MERGE_REF_RETRY_ATTEMPTS="$(plugin_read_config MERGE_REF_RETRY_ATTEMPTS "3")"
 
 if [[ "${CLEAN_CHECKOUT_OPTION}" = "true" ]]; then
   log_warning "clean_checkout is enabled - this will destroy any local changes and reset the repository state"

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -100,99 +100,10 @@ FETCH_FLAGS+=(--depth 1 origin)
 
 FETCH_OUTPUT=""
 
-run_fetch() {
-  local fetch_target=$1
-
-  if FETCH_OUTPUT=$(git fetch "${FETCH_FLAGS[@]}" "${fetch_target}" 2>&1); then
-    [[ -n "${FETCH_OUTPUT}" ]] && printf '%s\n' "${FETCH_OUTPUT}"
-    return 0
-  else
-    local status=$?
-    [[ -n "${FETCH_OUTPUT}" ]] && printf '%s\n' "${FETCH_OUTPUT}" >&2
-    return "${status}"
-  fi
-}
-
 is_missing_merge_ref_error() {
   local merge_ref="refs/pull/${BUILDKITE_PULL_REQUEST}/merge"
   [[ "${FETCH_OUTPUT}" == *"couldn't find remote ref ${merge_ref}"* ]] \
     || [[ "${FETCH_OUTPUT}" == *"not our ref ${merge_ref}"* ]]
-}
-
-fetch_default_target() {
-  if [[ ${BUILDKITE_COMMIT} = "HEAD" ]]; then
-    log_info "Fetching ${BUILDKITE_BRANCH} from origin"
-    if run_fetch "${BUILDKITE_BRANCH}"; then
-      return 0
-    else
-      local status=$?
-      log_error "Failed to fetch ${BUILDKITE_BRANCH} from origin"
-      return "${status}"
-    fi
-  else
-    log_info "Fetching ${BUILDKITE_COMMIT} from origin"
-    if run_fetch "${BUILDKITE_COMMIT}"; then
-      return 0
-    else
-      local status=$?
-      log_error "Failed to fetch ${BUILDKITE_COMMIT} from origin"
-      return "${status}"
-    fi
-  fi
-}
-
-checkout_default_target() {
-  log_info "Checking out ${BUILDKITE_COMMIT}"
-  if [[ ${BUILDKITE_COMMIT} = "HEAD" ]]; then
-    if ! git checkout FETCH_HEAD; then
-      log_error "Failed to checkout FETCH_HEAD"
-      return 1
-    fi
-  elif ! git checkout "${BUILDKITE_COMMIT}"; then
-    log_error "Failed to checkout ${BUILDKITE_COMMIT}"
-    return 1
-  fi
-}
-
-fetch_merge_ref_with_retries() {
-  local merge_ref="refs/pull/${BUILDKITE_PULL_REQUEST}/merge"
-
-  log_info "Fetching merge ref for PR #${BUILDKITE_PULL_REQUEST} from origin"
-  if run_fetch "${merge_ref}"; then
-    return 0
-  else
-    local status=$?
-    if ! is_missing_merge_ref_error; then
-      log_error "Failed to fetch merge ref for PR #${BUILDKITE_PULL_REQUEST} from origin"
-      return "${status}"
-    fi
-  fi
-
-  log_warning "Merge ref ${merge_ref} was not available yet; retrying in 2s"
-  sleep 2
-  if run_fetch "${merge_ref}"; then
-    return 0
-  else
-    status=$?
-    if ! is_missing_merge_ref_error; then
-      log_error "Failed to fetch merge ref for PR #${BUILDKITE_PULL_REQUEST} from origin"
-      return "${status}"
-    fi
-  fi
-
-  log_warning "Merge ref ${merge_ref} was still not available; retrying in 5s"
-  sleep 5
-  if run_fetch "${merge_ref}"; then
-    return 0
-  else
-    status=$?
-    if ! is_missing_merge_ref_error; then
-      log_error "Failed to fetch merge ref for PR #${BUILDKITE_PULL_REQUEST} from origin"
-      return "${status}"
-    fi
-  fi
-
-  return 2
 }
 
 # Determine if we should use the pull request merge refspec
@@ -200,32 +111,72 @@ USE_MERGE_REFSPEC="false"
 if [[ "${BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC:-false}" = "true" ]] \
   && [[ -n "${BUILDKITE_PULL_REQUEST:-}" ]] \
   && [[ "${BUILDKITE_PULL_REQUEST}" != "false" ]]; then
-  if fetch_merge_ref_with_retries; then
-    USE_MERGE_REFSPEC="true"
+  USE_MERGE_REFSPEC="true"
+  MERGE_REF="refs/pull/${BUILDKITE_PULL_REQUEST}/merge"
+
+  log_info "Fetching merge ref for PR #${BUILDKITE_PULL_REQUEST} from origin"
+  if FETCH_OUTPUT=$(git fetch "${FETCH_FLAGS[@]}" "${MERGE_REF}" 2>&1); then
+    [[ -n "${FETCH_OUTPUT}" ]] && printf '%s\n' "${FETCH_OUTPUT}"
   else
     status=$?
-    if [[ "${status}" -ne 2 ]]; then
+    [[ -n "${FETCH_OUTPUT}" ]] && printf '%s\n' "${FETCH_OUTPUT}" >&2
+    if ! is_missing_merge_ref_error; then
+      log_error "Failed to fetch merge ref for PR #${BUILDKITE_PULL_REQUEST} from origin"
       exit "${status}"
     fi
 
-    if [[ "${BUILDKITE_COMMIT}" = "HEAD" ]]; then
-      log_warning "Merge ref refs/pull/${BUILDKITE_PULL_REQUEST}/merge was still unavailable; falling back to branch ${BUILDKITE_BRANCH}"
-    else
-      log_warning "Merge ref refs/pull/${BUILDKITE_PULL_REQUEST}/merge was still unavailable; falling back to ${BUILDKITE_COMMIT}"
-    fi
-
-    if fetch_default_target; then
-      :
+    log_warning "Merge ref ${MERGE_REF} was not available yet; retrying in 2s"
+    sleep 2
+    if FETCH_OUTPUT=$(git fetch "${FETCH_FLAGS[@]}" "${MERGE_REF}" 2>&1); then
+      [[ -n "${FETCH_OUTPUT}" ]] && printf '%s\n' "${FETCH_OUTPUT}"
     else
       status=$?
-      exit "${status}"
+      [[ -n "${FETCH_OUTPUT}" ]] && printf '%s\n' "${FETCH_OUTPUT}" >&2
+      if ! is_missing_merge_ref_error; then
+        log_error "Failed to fetch merge ref for PR #${BUILDKITE_PULL_REQUEST} from origin"
+        exit "${status}"
+      fi
+
+      log_warning "Merge ref ${MERGE_REF} was still not available; retrying in 5s"
+      sleep 5
+      if FETCH_OUTPUT=$(git fetch "${FETCH_FLAGS[@]}" "${MERGE_REF}" 2>&1); then
+        [[ -n "${FETCH_OUTPUT}" ]] && printf '%s\n' "${FETCH_OUTPUT}"
+      else
+        status=$?
+        [[ -n "${FETCH_OUTPUT}" ]] && printf '%s\n' "${FETCH_OUTPUT}" >&2
+        if ! is_missing_merge_ref_error; then
+          log_error "Failed to fetch merge ref for PR #${BUILDKITE_PULL_REQUEST} from origin"
+          exit "${status}"
+        fi
+
+        if [[ "${BUILDKITE_COMMIT}" = "HEAD" ]]; then
+          log_warning "Merge ref ${MERGE_REF} was still unavailable; falling back to branch ${BUILDKITE_BRANCH}"
+        else
+          log_warning "Merge ref ${MERGE_REF} was still unavailable; falling back to ${BUILDKITE_COMMIT}"
+        fi
+
+        USE_MERGE_REFSPEC="false"
+      fi
     fi
   fi
-elif fetch_default_target; then
+fi
+
+if [[ "${USE_MERGE_REFSPEC}" != "true" ]]; then
+  if [[ ${BUILDKITE_COMMIT} = "HEAD" ]]; then
+    FETCH_FLAGS+=("${BUILDKITE_BRANCH}")
+  else
+    FETCH_FLAGS+=("${BUILDKITE_COMMIT}")
+  fi
+fi
+
+if [[ "${USE_MERGE_REFSPEC}" = "true" ]]; then
   :
 else
-  status=$?
-  exit "${status}"
+  log_info "Fetching ${BUILDKITE_COMMIT} from origin"
+  if ! git fetch "${FETCH_FLAGS[@]}"; then
+    log_error "Failed to fetch ${BUILDKITE_COMMIT} from origin"
+    exit 1
+  fi
 fi
 log_success "Fetch completed successfully"
 
@@ -241,10 +192,18 @@ if [[ "${USE_MERGE_REFSPEC}" = "true" ]]; then
     log_error "Failed to checkout FETCH_HEAD"
     exit 1
   fi
-elif checkout_default_target; then
-  :
 else
-  status=$?
-  exit "${status}"
+  log_info "Checking out ${BUILDKITE_COMMIT}"
+  if [[ ${BUILDKITE_COMMIT} = "HEAD" ]]; then
+    if ! git checkout FETCH_HEAD; then
+      log_error "Failed to checkout FETCH_HEAD"
+      exit 1
+    fi
+  else
+    if ! git checkout "${BUILDKITE_COMMIT}"; then
+      log_error "Failed to checkout ${BUILDKITE_COMMIT}"
+      exit 1
+    fi
+  fi
 fi
 log_success "Sparse checkout completed successfully"

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -30,6 +30,13 @@ fi
 SKIP_SSH_KEYSCAN_OPTION="$(plugin_read_config SKIP_SSH_KEYSCAN "false")"
 CLEAN_CHECKOUT_OPTION="$(plugin_read_config CLEAN_CHECKOUT "false")"
 
+MERGE_REF_RETRY_ATTEMPTS_RAW="$(plugin_read_config MERGE_REF_RETRY_ATTEMPTS "3")"
+if [[ "${MERGE_REF_RETRY_ATTEMPTS_RAW}" =~ ^[0-9]+$ ]]; then
+  MERGE_REF_RETRY_ATTEMPTS="${MERGE_REF_RETRY_ATTEMPTS_RAW}"
+else
+  MERGE_REF_RETRY_ATTEMPTS=3
+fi
+
 if [[ "${CLEAN_CHECKOUT_OPTION}" = "true" ]]; then
   log_warning "clean_checkout is enabled - this will destroy any local changes and reset the repository state"
 fi
@@ -106,6 +113,25 @@ is_missing_merge_ref_error() {
     || [[ "${FETCH_OUTPUT}" == *"not our ref ${merge_ref}"* ]]
 }
 
+# Try to fetch merge ref. Returns 0 on success, 1 if merge ref is missing (retry),
+# otherwise logs and exits with git's status.
+try_fetch_merge_ref() {
+  local merge_ref="$1"
+  if FETCH_OUTPUT=$(git fetch "${FETCH_FLAGS[@]}" "${merge_ref}" 2>&1); then
+    [[ -n "${FETCH_OUTPUT}" ]] && printf '%s\n' "${FETCH_OUTPUT}"
+    return 0
+  else
+    local status=$?
+    [[ -n "${FETCH_OUTPUT}" ]] && printf '%s\n' "${FETCH_OUTPUT}" >&2
+    if is_missing_merge_ref_error; then
+      return 1
+    else
+      log_error "Failed to fetch merge ref for PR #${BUILDKITE_PULL_REQUEST} from origin"
+      exit "${status}"
+    fi
+  fi
+}
+
 # Determine if we should use the pull request merge refspec
 USE_MERGE_REFSPEC="false"
 if [[ "${BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC:-false}" = "true" ]] \
@@ -115,49 +141,32 @@ if [[ "${BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC:-false}" = "true" ]] \
   MERGE_REF="refs/pull/${BUILDKITE_PULL_REQUEST}/merge"
 
   log_info "Fetching merge ref for PR #${BUILDKITE_PULL_REQUEST} from origin"
-  if FETCH_OUTPUT=$(git fetch "${FETCH_FLAGS[@]}" "${MERGE_REF}" 2>&1); then
-    [[ -n "${FETCH_OUTPUT}" ]] && printf '%s\n' "${FETCH_OUTPUT}"
-  else
-    status=$?
-    [[ -n "${FETCH_OUTPUT}" ]] && printf '%s\n' "${FETCH_OUTPUT}" >&2
-    if ! is_missing_merge_ref_error; then
-      log_error "Failed to fetch merge ref for PR #${BUILDKITE_PULL_REQUEST} from origin"
-      exit "${status}"
+
+  fetch_succeeded=false
+  for ((attempt = 1; attempt <= MERGE_REF_RETRY_ATTEMPTS; attempt++)); do
+    if try_fetch_merge_ref "${MERGE_REF}"; then
+      fetch_succeeded=true
+      break
     fi
 
-    log_warning "Merge ref ${MERGE_REF} was not available yet; retrying in 2s"
-    sleep 2
-    if FETCH_OUTPUT=$(git fetch "${FETCH_FLAGS[@]}" "${MERGE_REF}" 2>&1); then
-      [[ -n "${FETCH_OUTPUT}" ]] && printf '%s\n' "${FETCH_OUTPUT}"
-    else
-      status=$?
-      [[ -n "${FETCH_OUTPUT}" ]] && printf '%s\n' "${FETCH_OUTPUT}" >&2
-      if ! is_missing_merge_ref_error; then
-        log_error "Failed to fetch merge ref for PR #${BUILDKITE_PULL_REQUEST} from origin"
-        exit "${status}"
-      fi
-
-      log_warning "Merge ref ${MERGE_REF} was still not available; retrying in 5s"
-      sleep 5
-      if FETCH_OUTPUT=$(git fetch "${FETCH_FLAGS[@]}" "${MERGE_REF}" 2>&1); then
-        [[ -n "${FETCH_OUTPUT}" ]] && printf '%s\n' "${FETCH_OUTPUT}"
+    if [[ "${attempt}" -lt "${MERGE_REF_RETRY_ATTEMPTS}" ]]; then
+      if [[ "${attempt}" -eq 1 ]]; then
+        log_warning "Merge ref ${MERGE_REF} was not available yet; retrying in 2s"
+        sleep 2
       else
-        status=$?
-        [[ -n "${FETCH_OUTPUT}" ]] && printf '%s\n' "${FETCH_OUTPUT}" >&2
-        if ! is_missing_merge_ref_error; then
-          log_error "Failed to fetch merge ref for PR #${BUILDKITE_PULL_REQUEST} from origin"
-          exit "${status}"
-        fi
-
-        if [[ "${BUILDKITE_COMMIT}" = "HEAD" ]]; then
-          log_warning "Merge ref ${MERGE_REF} was still unavailable; falling back to branch ${BUILDKITE_BRANCH}"
-        else
-          log_warning "Merge ref ${MERGE_REF} was still unavailable; falling back to ${BUILDKITE_COMMIT}"
-        fi
-
-        USE_MERGE_REFSPEC="false"
+        log_warning "Merge ref ${MERGE_REF} was not available yet; retrying in 5s"
+        sleep 5
       fi
     fi
+  done
+
+  if [[ "${fetch_succeeded}" != "true" ]]; then
+    if [[ "${BUILDKITE_COMMIT}" = "HEAD" ]]; then
+      log_warning "Merge ref ${MERGE_REF} was still unavailable; falling back to branch ${BUILDKITE_BRANCH}"
+    else
+      log_warning "Merge ref ${MERGE_REF} was still unavailable; falling back to ${BUILDKITE_COMMIT}"
+    fi
+    USE_MERGE_REFSPEC="false"
   fi
 fi
 

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -98,36 +98,12 @@ fi
 
 FETCH_FLAGS+=(--depth 1 origin)
 
-# Determine if we should use the pull request merge refspec
-USE_MERGE_REFSPEC="false"
-FETCH_TARGET=""
-FETCH_TARGET_DESCRIPTION=""
-CHECKOUT_TARGET=""
-CHECKOUT_DESCRIPTION=""
-if [[ "${BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC:-false}" = "true" ]] \
-  && [[ -n "${BUILDKITE_PULL_REQUEST:-}" ]] \
-  && [[ "${BUILDKITE_PULL_REQUEST}" != "false" ]]; then
-  USE_MERGE_REFSPEC="true"
-  FETCH_TARGET="refs/pull/${BUILDKITE_PULL_REQUEST}/merge"
-  FETCH_TARGET_DESCRIPTION="merge ref ${FETCH_TARGET} from origin"
-  CHECKOUT_TARGET="FETCH_HEAD"
-  CHECKOUT_DESCRIPTION="merge ref for PR #${BUILDKITE_PULL_REQUEST}"
-elif [[ ${BUILDKITE_COMMIT} = "HEAD" ]]; then
-  FETCH_TARGET="${BUILDKITE_BRANCH}"
-  FETCH_TARGET_DESCRIPTION="branch ${BUILDKITE_BRANCH} from origin"
-  CHECKOUT_TARGET="FETCH_HEAD"
-  CHECKOUT_DESCRIPTION="${BUILDKITE_BRANCH}"
-else
-  FETCH_TARGET="${BUILDKITE_COMMIT}"
-  FETCH_TARGET_DESCRIPTION="${BUILDKITE_COMMIT} from origin"
-  CHECKOUT_TARGET="${BUILDKITE_COMMIT}"
-  CHECKOUT_DESCRIPTION="${BUILDKITE_COMMIT}"
-fi
-
 FETCH_OUTPUT=""
 
 run_fetch() {
-  if FETCH_OUTPUT=$(git fetch "${FETCH_FLAGS[@]}" "${FETCH_TARGET}" 2>&1); then
+  local fetch_target=$1
+
+  if FETCH_OUTPUT=$(git fetch "${FETCH_FLAGS[@]}" "${fetch_target}" 2>&1); then
     [[ -n "${FETCH_OUTPUT}" ]] && printf '%s\n' "${FETCH_OUTPUT}"
     return 0
   else
@@ -143,69 +119,112 @@ is_missing_merge_ref_error() {
     || [[ "${FETCH_OUTPUT}" == *"not our ref ${merge_ref}"* ]]
 }
 
-log_info "Fetching ${FETCH_TARGET_DESCRIPTION}"
-if [[ "${USE_MERGE_REFSPEC}" = "true" ]]; then
-  if run_fetch; then
-    :
+fetch_default_target() {
+  if [[ ${BUILDKITE_COMMIT} = "HEAD" ]]; then
+    log_info "Fetching ${BUILDKITE_BRANCH} from origin"
+    if run_fetch "${BUILDKITE_BRANCH}"; then
+      return 0
+    else
+      local status=$?
+      log_error "Failed to fetch ${BUILDKITE_BRANCH} from origin"
+      return "${status}"
+    fi
+  else
+    log_info "Fetching ${BUILDKITE_COMMIT} from origin"
+    if run_fetch "${BUILDKITE_COMMIT}"; then
+      return 0
+    else
+      local status=$?
+      log_error "Failed to fetch ${BUILDKITE_COMMIT} from origin"
+      return "${status}"
+    fi
+  fi
+}
+
+checkout_default_target() {
+  log_info "Checking out ${BUILDKITE_COMMIT}"
+  if [[ ${BUILDKITE_COMMIT} = "HEAD" ]]; then
+    if ! git checkout FETCH_HEAD; then
+      log_error "Failed to checkout FETCH_HEAD"
+      return 1
+    fi
+  elif ! git checkout "${BUILDKITE_COMMIT}"; then
+    log_error "Failed to checkout ${BUILDKITE_COMMIT}"
+    return 1
+  fi
+}
+
+fetch_merge_ref_with_retries() {
+  local merge_ref="refs/pull/${BUILDKITE_PULL_REQUEST}/merge"
+
+  log_info "Fetching merge ref for PR #${BUILDKITE_PULL_REQUEST} from origin"
+  if run_fetch "${merge_ref}"; then
+    return 0
+  else
+    local status=$?
+    if ! is_missing_merge_ref_error; then
+      log_error "Failed to fetch merge ref for PR #${BUILDKITE_PULL_REQUEST} from origin"
+      return "${status}"
+    fi
+  fi
+
+  log_warning "Merge ref ${merge_ref} was not available yet; retrying in 2s"
+  sleep 2
+  if run_fetch "${merge_ref}"; then
+    return 0
   else
     status=$?
     if ! is_missing_merge_ref_error; then
-      log_error "Failed to fetch ${FETCH_TARGET_DESCRIPTION}"
+      log_error "Failed to fetch merge ref for PR #${BUILDKITE_PULL_REQUEST} from origin"
+      return "${status}"
+    fi
+  fi
+
+  log_warning "Merge ref ${merge_ref} was still not available; retrying in 5s"
+  sleep 5
+  if run_fetch "${merge_ref}"; then
+    return 0
+  else
+    status=$?
+    if ! is_missing_merge_ref_error; then
+      log_error "Failed to fetch merge ref for PR #${BUILDKITE_PULL_REQUEST} from origin"
+      return "${status}"
+    fi
+  fi
+
+  return 2
+}
+
+# Determine if we should use the pull request merge refspec
+USE_MERGE_REFSPEC="false"
+if [[ "${BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC:-false}" = "true" ]] \
+  && [[ -n "${BUILDKITE_PULL_REQUEST:-}" ]] \
+  && [[ "${BUILDKITE_PULL_REQUEST}" != "false" ]]; then
+  if fetch_merge_ref_with_retries; then
+    USE_MERGE_REFSPEC="true"
+  else
+    status=$?
+    if [[ "${status}" -ne 2 ]]; then
       exit "${status}"
     fi
 
-    log_warning "Merge ref ${FETCH_TARGET} was not available yet; retrying in 2s"
-    sleep 2
-    if run_fetch; then
+    if [[ "${BUILDKITE_COMMIT}" = "HEAD" ]]; then
+      log_warning "Merge ref refs/pull/${BUILDKITE_PULL_REQUEST}/merge was still unavailable; falling back to branch ${BUILDKITE_BRANCH}"
+    else
+      log_warning "Merge ref refs/pull/${BUILDKITE_PULL_REQUEST}/merge was still unavailable; falling back to ${BUILDKITE_COMMIT}"
+    fi
+
+    if fetch_default_target; then
       :
     else
       status=$?
-      if ! is_missing_merge_ref_error; then
-        log_error "Failed to fetch ${FETCH_TARGET_DESCRIPTION}"
-        exit "${status}"
-      fi
-
-      log_warning "Merge ref ${FETCH_TARGET} was still not available; retrying in 5s"
-      sleep 5
-      if run_fetch; then
-        :
-      else
-        status=$?
-        if ! is_missing_merge_ref_error; then
-          log_error "Failed to fetch ${FETCH_TARGET_DESCRIPTION}"
-          exit "${status}"
-        fi
-
-        if [[ "${BUILDKITE_COMMIT}" = "HEAD" ]]; then
-          log_warning "Merge ref ${FETCH_TARGET} was still unavailable; falling back to branch ${BUILDKITE_BRANCH}"
-          FETCH_TARGET="${BUILDKITE_BRANCH}"
-          FETCH_TARGET_DESCRIPTION="fallback branch ${BUILDKITE_BRANCH} from origin"
-          CHECKOUT_TARGET="FETCH_HEAD"
-          CHECKOUT_DESCRIPTION="${BUILDKITE_BRANCH}"
-        else
-          log_warning "Merge ref ${FETCH_TARGET} was still unavailable; falling back to ${BUILDKITE_COMMIT}"
-          FETCH_TARGET="${BUILDKITE_COMMIT}"
-          FETCH_TARGET_DESCRIPTION="fallback commit ${BUILDKITE_COMMIT} from origin"
-          CHECKOUT_TARGET="${BUILDKITE_COMMIT}"
-          CHECKOUT_DESCRIPTION="${BUILDKITE_COMMIT}"
-        fi
-        USE_MERGE_REFSPEC="false"
-
-        if run_fetch; then
-          :
-        else
-          status=$?
-          log_error "Failed to fetch ${FETCH_TARGET_DESCRIPTION}"
-          exit "${status}"
-        fi
-      fi
+      exit "${status}"
     fi
   fi
-elif run_fetch; then
+elif fetch_default_target; then
   :
 else
   status=$?
-  log_error "Failed to fetch ${FETCH_TARGET_DESCRIPTION}"
   exit "${status}"
 fi
 log_success "Fetch completed successfully"
@@ -216,15 +235,16 @@ if ! git sparse-checkout set ${NO_CONE_PARAM:+--no-cone} "${CHECKOUT_PATHS[@]}";
   exit 1
 fi
 
-log_info "Checking out ${CHECKOUT_DESCRIPTION}"
-if [[ "${CHECKOUT_TARGET}" = "FETCH_HEAD" ]]; then
+if [[ "${USE_MERGE_REFSPEC}" = "true" ]]; then
+  log_info "Checking out merge ref for PR #${BUILDKITE_PULL_REQUEST}"
   if ! git checkout FETCH_HEAD; then
     log_error "Failed to checkout FETCH_HEAD"
     exit 1
   fi
-elif ! git checkout "${CHECKOUT_TARGET}"; then
-  log_error "Failed to checkout ${CHECKOUT_TARGET}"
-  exit 1
+elif checkout_default_target; then
+  :
+else
+  status=$?
+  exit "${status}"
 fi
-
 log_success "Sparse checkout completed successfully"

--- a/plugin.yml
+++ b/plugin.yml
@@ -16,6 +16,9 @@ configuration:
     clean_checkout:
       type: boolean
       default: false
+    merge_ref_retry_attempts:
+      type: integer
+      default: 3
     verbose:
       type: boolean
       default: false

--- a/tests/checkout.bats
+++ b/tests/checkout.bats
@@ -247,33 +247,6 @@ setup() {
   unstub git
 }
 
-@test "Falls back to the default fetch path when merge ref retries are exhausted" {
-  export BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC="true"
-  export BUILDKITE_PULL_REQUEST="123"
-  export BUILDKITE_COMMIT="abc123"
-
-  stub ssh-keyscan "* : echo 'keyscan'"
-  stub sleep \
-    "2 : true" \
-    "5 : true"
-  stub git \
-    "clean * : echo 'git clean'" \
-    "fetch --depth 1 origin refs/pull/123/merge : echo \"fatal: couldn't find remote ref refs/pull/123/merge\" >&2; exit 1" \
-    "fetch --depth 1 origin refs/pull/123/merge : echo \"fatal: couldn't find remote ref refs/pull/123/merge\" >&2; exit 1" \
-    "fetch --depth 1 origin refs/pull/123/merge : echo \"fatal: couldn't find remote ref refs/pull/123/merge\" >&2; exit 1" \
-    "fetch --depth 1 origin abc123 : echo 'fatal: bad object abc123' >&2; exit 1"
-
-  run "$PWD"/hooks/checkout
-
-  assert_failure
-  assert_output --partial 'falling back to abc123'
-  assert_output --partial 'Failed to fetch abc123 from origin'
-
-  unstub sleep
-  unstub ssh-keyscan
-  unstub git
-}
-
 @test "Does not use merge refspec when BUILDKITE_PULL_REQUEST is false" {
   export BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC="true"
   export BUILDKITE_PULL_REQUEST="false"

--- a/tests/checkout.bats
+++ b/tests/checkout.bats
@@ -11,7 +11,6 @@ setup() {
   export BUILDKITE_REPO_SSH_HOST="default_host"
   export BUILDKITE_COMMIT="dummy-commit-hash"
   export BUILDKITE_REPO="git@github.com:example/repo.git"
-  mkdir -p .git
 }
 
 @test "Skip ssh-keyscan when option provided" {
@@ -209,37 +208,6 @@ setup() {
   assert_output --partial 'retrying in 2s'
   assert_output --partial 'retrying in 5s'
   assert_output --partial 'git fetch merge refspec'
-  assert_output --partial 'checkout fetch_head'
-
-  unstub sleep
-  unstub ssh-keyscan
-  unstub git
-}
-
-@test "Falls back to the branch when BUILDKITE_COMMIT is HEAD" {
-  export BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC="true"
-  export BUILDKITE_PULL_REQUEST="123"
-  export BUILDKITE_COMMIT="HEAD"
-  export BUILDKITE_BRANCH="feature-branch"
-
-  stub ssh-keyscan "* : echo 'keyscan'"
-  stub sleep \
-    "2 : true" \
-    "5 : true"
-  stub git \
-    "clean * : echo 'git clean'" \
-    "fetch --depth 1 origin refs/pull/123/merge : echo \"fatal: couldn't find remote ref refs/pull/123/merge\" >&2; exit 1" \
-    "fetch --depth 1 origin refs/pull/123/merge : echo \"fatal: couldn't find remote ref refs/pull/123/merge\" >&2; exit 1" \
-    "fetch --depth 1 origin refs/pull/123/merge : echo \"fatal: couldn't find remote ref refs/pull/123/merge\" >&2; exit 1" \
-    "fetch --depth 1 origin feature-branch : echo 'git fetch fallback branch'" \
-    "sparse-checkout set * * : echo 'git sparse-checkout'" \
-    "checkout FETCH_HEAD : echo 'checkout fetch_head'"
-
-  run "$PWD"/hooks/checkout
-
-  assert_success
-  assert_output --partial 'falling back to branch feature-branch'
-  assert_output --partial 'git fetch fallback branch'
   assert_output --partial 'checkout fetch_head'
 
   unstub sleep

--- a/tests/checkout.bats
+++ b/tests/checkout.bats
@@ -11,6 +11,7 @@ setup() {
   export BUILDKITE_REPO_SSH_HOST="default_host"
   export BUILDKITE_COMMIT="dummy-commit-hash"
   export BUILDKITE_REPO="git@github.com:example/repo.git"
+  mkdir -p .git
 }
 
 @test "Skip ssh-keyscan when option provided" {
@@ -181,6 +182,94 @@ setup() {
   assert_output --partial 'git fetch merge refspec'
   assert_output --partial 'checkout fetch_head'
 
+  unstub ssh-keyscan
+  unstub git
+}
+
+@test "Retries missing merge ref before succeeding" {
+  export BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC="true"
+  export BUILDKITE_PULL_REQUEST="123"
+  export BUILDKITE_COMMIT="abc123"
+
+  stub ssh-keyscan "* : echo 'keyscan'"
+  stub sleep \
+    "2 : true" \
+    "5 : true"
+  stub git \
+    "clean * : echo 'git clean'" \
+    "fetch --depth 1 origin refs/pull/123/merge : echo \"fatal: couldn't find remote ref refs/pull/123/merge\" >&2; exit 1" \
+    "fetch --depth 1 origin refs/pull/123/merge : echo \"fatal: couldn't find remote ref refs/pull/123/merge\" >&2; exit 1" \
+    "fetch --depth 1 origin refs/pull/123/merge : echo 'git fetch merge refspec'" \
+    "sparse-checkout set * * : echo 'git sparse-checkout'" \
+    "checkout FETCH_HEAD : echo 'checkout fetch_head'"
+
+  run "$PWD"/hooks/checkout
+
+  assert_success
+  assert_output --partial 'retrying in 2s'
+  assert_output --partial 'retrying in 5s'
+  assert_output --partial 'git fetch merge refspec'
+  assert_output --partial 'checkout fetch_head'
+
+  unstub sleep
+  unstub ssh-keyscan
+  unstub git
+}
+
+@test "Falls back to the branch when BUILDKITE_COMMIT is HEAD" {
+  export BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC="true"
+  export BUILDKITE_PULL_REQUEST="123"
+  export BUILDKITE_COMMIT="HEAD"
+  export BUILDKITE_BRANCH="feature-branch"
+
+  stub ssh-keyscan "* : echo 'keyscan'"
+  stub sleep \
+    "2 : true" \
+    "5 : true"
+  stub git \
+    "clean * : echo 'git clean'" \
+    "fetch --depth 1 origin refs/pull/123/merge : echo \"fatal: couldn't find remote ref refs/pull/123/merge\" >&2; exit 1" \
+    "fetch --depth 1 origin refs/pull/123/merge : echo \"fatal: couldn't find remote ref refs/pull/123/merge\" >&2; exit 1" \
+    "fetch --depth 1 origin refs/pull/123/merge : echo \"fatal: couldn't find remote ref refs/pull/123/merge\" >&2; exit 1" \
+    "fetch --depth 1 origin feature-branch : echo 'git fetch fallback branch'" \
+    "sparse-checkout set * * : echo 'git sparse-checkout'" \
+    "checkout FETCH_HEAD : echo 'checkout fetch_head'"
+
+  run "$PWD"/hooks/checkout
+
+  assert_success
+  assert_output --partial 'falling back to branch feature-branch'
+  assert_output --partial 'git fetch fallback branch'
+  assert_output --partial 'checkout fetch_head'
+
+  unstub sleep
+  unstub ssh-keyscan
+  unstub git
+}
+
+@test "Fails when the head commit fallback fetch fails" {
+  export BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC="true"
+  export BUILDKITE_PULL_REQUEST="123"
+  export BUILDKITE_COMMIT="abc123"
+
+  stub ssh-keyscan "* : echo 'keyscan'"
+  stub sleep \
+    "2 : true" \
+    "5 : true"
+  stub git \
+    "clean * : echo 'git clean'" \
+    "fetch --depth 1 origin refs/pull/123/merge : echo \"fatal: couldn't find remote ref refs/pull/123/merge\" >&2; exit 1" \
+    "fetch --depth 1 origin refs/pull/123/merge : echo \"fatal: couldn't find remote ref refs/pull/123/merge\" >&2; exit 1" \
+    "fetch --depth 1 origin refs/pull/123/merge : echo \"fatal: couldn't find remote ref refs/pull/123/merge\" >&2; exit 1" \
+    "fetch --depth 1 origin abc123 : echo 'fatal: bad object abc123' >&2; exit 1"
+
+  run "$PWD"/hooks/checkout
+
+  assert_failure
+  assert_output --partial 'falling back to abc123'
+  assert_output --partial 'Failed to fetch fallback commit abc123 from origin'
+
+  unstub sleep
   unstub ssh-keyscan
   unstub git
 }

--- a/tests/checkout.bats
+++ b/tests/checkout.bats
@@ -247,7 +247,7 @@ setup() {
   unstub git
 }
 
-@test "Fails when the head commit fallback fetch fails" {
+@test "Falls back to the default fetch path when merge ref retries are exhausted" {
   export BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC="true"
   export BUILDKITE_PULL_REQUEST="123"
   export BUILDKITE_COMMIT="abc123"
@@ -267,7 +267,7 @@ setup() {
 
   assert_failure
   assert_output --partial 'falling back to abc123'
-  assert_output --partial 'Failed to fetch fallback commit abc123 from origin'
+  assert_output --partial 'Failed to fetch abc123 from origin'
 
   unstub sleep
   unstub ssh-keyscan


### PR DESCRIPTION
We've seen an increase in errors when using v.1.6.0 which adds supports for `BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC`. 

The error looks like:
```
2026-03-19 03:19:06 UTC
Running plugin sparse-checkout-buildkite-plugin checkout hook
2026-03-19 03:19:06 UTC
$ /var/lib/buildkite-agent/plugins/any-ue1-buildkite-buildkite-dd807e16-i-0cbb5f3167f1c00f1-2/github-com-buildkite-plugins-sparse-checkout-buildkite-plugin-v1-6-0/hooks/checkout
2026-03-19 03:19:06 UTC
[WARNING]: clean_checkout is enabled - this will destroy any local changes and reset the repository state
2026-03-19 03:19:06 UTC
[INFO]: Skipped SSH keyscan
2026-03-19 03:19:06 UTC
[INFO]: Creating sparse-checkout with paths: .buildkite
2026-03-19 03:19:06 UTC
[INFO]: Clean checkout enabled - resetting repository state
2026-03-19 03:19:06 UTC
HEAD is now at a665c61d Deploy auto-promote cron with dual-write (#83221)
2026-03-19 03:19:06 UTC
[INFO]: Fetching merge ref for PR #83321 from origin
2026-03-19 03:19:06 UTC
fatal: couldn't find remote ref refs/pull/83321/merge
2026-03-19 03:19:06 UTC
[ERROR]: Failed to fetch 426a5132f83a6af26bb2e6f4b5de665014ece393 from origin
2026-03-19 03:19:06 UTC
🚨 Error: running "plugin sparse-checkout-buildkite-plugin checkout" shell hook: The plugin sparse-checkout-buildkite-plugin checkout hook exited with status 1
```

One theory is the merge commit is not available from github yet. This PR attempts to resolve this by adding some retries around the fetching of the merge commit.

May want to consider adding some configuration to this PR (retry count / delay / fallback) -- but I think we can also do that in response to feedback.

Update: This seems to be have fixed this error for us!