### PR TITLE
Add `cleanup_sparse_state` option to prevent sparse-checkout state leaking between jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ steps:
   - label: "Pipeline upload"
     command: "buildkite-agent pipeline upload"
     plugins:
-      - sparse-checkout#v1.5.0:
+      - sparse-checkout#v1.6.0:
           paths:
             - .buildkite
 ```
@@ -90,7 +90,7 @@ steps:
   - label: "Build with full history"
     command: "make changelog"
     plugins:
-      - sparse-checkout#v1.5.0:
+      - sparse-checkout#v1.6.0:
           paths:
             - src
             - .buildkite
@@ -107,7 +107,7 @@ steps:
   - label: "Pipeline upload with clean checkout"
     command: "buildkite-agent pipeline upload"
     plugins:
-      - sparse-checkout#v1.5.0:
+      - sparse-checkout#v1.6.0:
           paths:
             - .buildkite
           clean_checkout: true
@@ -122,7 +122,7 @@ steps:
   - label: "Sparse build"
     command: "make build"
     plugins:
-      - sparse-checkout#v1.5.0:
+      - sparse-checkout#v1.6.0:
           paths:
             - src
           cleanup_worktree_config: true

--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ Tear down sparse-checkout state after the job finishes, so that subsequent jobs 
 
 When `git sparse-checkout` runs, it writes `.git/config.worktree` and sets `extensions.worktreeConfig`, `core.sparseCheckout`, and `core.sparseCheckoutCone` in git config. On agents with persistent build directories, this state persists across jobs — causing subsequent non-sparse jobs to silently inherit the sparse paths and fail to find files outside them.
 
+In most setups you do not need this option. The plugin's `hooks/environment` already isolates sparse checkouts into a `-sparse`-suffixed build directory, so non-sparse jobs on the same agent land elsewhere and never see sparse state. Enable `cleanup_sparse_state` only when your agent configuration overrides `BUILDKITE_BUILD_CHECKOUT_PATH` after the plugin's env hook runs, causing sparse and non-sparse checkouts to share the same directory.
+
 Cleanup runs at `pre-exit` after the job's command finishes, so the next job on the same directory starts clean. This runs regardless of job success or failure. Cleanup runs at `pre-exit` rather than `post-checkout` so that sparse state stays active for the duration of the job command.
 
 A second pass runs at `pre-checkout` as a safety net for cases where a previous job's `pre-exit` never fired (for example, agent crashes or `SIGKILL`).
 
 The cleanup removes `.git/config.worktree` and unsets `extensions.worktreeConfig`, `core.sparseCheckout`, and `core.sparseCheckoutCone`. The working tree files are left intact. This deliberately avoids `git sparse-checkout disable`, which re-materialises the full working tree (expensive on large monorepos).
-
-Recommended for shared agent fleets with persistent build directories where sparse and non-sparse pipelines may run on the same agent.
 
 #### `verbose` ('true' or 'false')
 
@@ -110,9 +110,9 @@ steps:
           clean_checkout: true
 ```
 
-### Cleaning up sparse-checkout state for shared agent fleets
+### Cleaning up sparse-checkout state when the default path isolation is overridden
 
-On agents with persistent build directories, sparse-checkout leaves behind git config state that causes subsequent non-sparse jobs to silently inherit the sparse paths and fail. Enable `cleanup_sparse_state` to clean this up before and after each sparse checkout:
+If your agent configuration causes sparse and non-sparse jobs to share the same checkout directory (overriding the plugin's `-sparse` path isolation), sparse-checkout state can leak between them. Enable `cleanup_sparse_state` to clean this up at `pre-exit` and `pre-checkout`:
 
 ```yaml
 steps:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,23 @@ Whether to perform aggressive repository cleanup before checkout. This option ha
 
 Use this option for pipeline upload jobs that don't need to preserve local changes.
 
+#### `cleanup_worktree_config` ('true' or 'false')
+
+Remove the sparse-checkout worktree config after checkout completes, so that subsequent jobs on the same agent that do **not** use sparse checkout are not affected.
+
+When `git sparse-checkout` runs, it writes `.git/config.worktree` and sets `extensions.worktreeConfig`, `core.sparseCheckout`, and `core.sparseCheckoutCone` in git config. On agents with persistent build directories, this state persists across jobs — causing subsequent non-sparse jobs to silently inherit the sparse paths and fail to find files outside them.
+
+Enabling this option runs cleanup in two places:
+
+- **`pre-checkout`**: clears stale sparse config at the start of each run, before the new checkout begins. Handles interrupted jobs where post-checkout never fired.
+- **`post-checkout`**: clears sparse config after the checkout completes, so the next job on the same directory starts clean.
+
+The cleanup removes `.git/config.worktree` and unsets `extensions.worktreeConfig`, `core.sparseCheckout`, and `core.sparseCheckoutCone`. The working tree files are left intact. This deliberately avoids `git sparse-checkout disable`, which re-materialises the full working tree (expensive on large monorepos).
+
+This can also be enabled without modifying individual pipeline configs by setting `SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG=true` as an agent environment variable — useful for enforcing the behaviour fleet-wide.
+
+**Recommended for:** shared agent fleets with persistent build directories where sparse and non-sparse pipelines may run on the same agent.
+
 #### `verbose` ('true' or 'false')
 
 Enable verbose logging with bash execution tracing (`set -x`). This shows each command being executed and can help debug issues with ssh-keyscan, git operations, or other checkout problems. When enabled, you'll see detailed output including command arguments and any error messages from underlying tools.
@@ -95,6 +112,23 @@ steps:
             - .buildkite
           clean_checkout: true
 ```
+
+### Cleaning up worktree config for shared agent fleets
+
+On agents with persistent build directories, sparse-checkout leaves behind git config state that causes subsequent non-sparse jobs to silently inherit the sparse paths and fail. Enable `cleanup_worktree_config` to clean this up before and after each sparse checkout:
+
+```yaml
+steps:
+  - label: "Sparse build"
+    command: "make build"
+    plugins:
+      - sparse-checkout#v1.5.0:
+          paths:
+            - src
+          cleanup_worktree_config: true
+```
+
+The plugin will clean up stale sparse config in `pre-checkout` (protecting the current run from a previous interrupted job) and again in `post-checkout` (protecting the next run from our own sparse state).
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ Whether to perform aggressive repository cleanup before checkout. This option ha
 
 Use this option for pipeline upload jobs that don't need to preserve local changes.
 
-#### `cleanup_worktree_config` ('true' or 'false')
+#### `cleanup_sparse_state` ('true' or 'false')
 
-Remove the sparse-checkout worktree config after checkout completes, so that subsequent jobs on the same agent that do **not** use sparse checkout are not affected.
+Tear down sparse-checkout state after the job finishes, so that subsequent jobs on the same agent that do **not** use sparse checkout are not affected.
 
 When `git sparse-checkout` runs, it writes `.git/config.worktree` and sets `extensions.worktreeConfig`, `core.sparseCheckout`, and `core.sparseCheckoutCone` in git config. On agents with persistent build directories, this state persists across jobs — causing subsequent non-sparse jobs to silently inherit the sparse paths and fail to find files outside them.
 
@@ -110,9 +110,9 @@ steps:
           clean_checkout: true
 ```
 
-### Cleaning up worktree config for shared agent fleets
+### Cleaning up sparse-checkout state for shared agent fleets
 
-On agents with persistent build directories, sparse-checkout leaves behind git config state that causes subsequent non-sparse jobs to silently inherit the sparse paths and fail. Enable `cleanup_worktree_config` to clean this up before and after each sparse checkout:
+On agents with persistent build directories, sparse-checkout leaves behind git config state that causes subsequent non-sparse jobs to silently inherit the sparse paths and fail. Enable `cleanup_sparse_state` to clean this up before and after each sparse checkout:
 
 ```yaml
 steps:
@@ -122,7 +122,7 @@ steps:
       - sparse-checkout#v1.6.0:
           paths:
             - src
-          cleanup_worktree_config: true
+          cleanup_sparse_state: true
 ```
 
 The plugin will clean up stale sparse config in `pre-exit` (protecting the next job on the same directory from our own sparse state) and again in `pre-checkout` (protecting the current run from a previous interrupted job where `pre-exit` never fired).

--- a/README.md
+++ b/README.md
@@ -44,16 +44,13 @@ Remove the sparse-checkout worktree config after checkout completes, so that sub
 
 When `git sparse-checkout` runs, it writes `.git/config.worktree` and sets `extensions.worktreeConfig`, `core.sparseCheckout`, and `core.sparseCheckoutCone` in git config. On agents with persistent build directories, this state persists across jobs — causing subsequent non-sparse jobs to silently inherit the sparse paths and fail to find files outside them.
 
-Enabling this option runs cleanup in two places:
+Cleanup runs at `pre-exit` after the job's command finishes, so the next job on the same directory starts clean. This runs regardless of job success or failure. Cleanup runs at `pre-exit` rather than `post-checkout` so that sparse state stays active for the duration of the job command.
 
-- **`pre-checkout`**: clears stale sparse config at the start of each run, before the new checkout begins. Handles interrupted jobs where post-checkout never fired.
-- **`post-checkout`**: clears sparse config after the checkout completes, so the next job on the same directory starts clean.
+A second pass runs at `pre-checkout` as a safety net for cases where a previous job's `pre-exit` never fired (for example, agent crashes or `SIGKILL`).
 
 The cleanup removes `.git/config.worktree` and unsets `extensions.worktreeConfig`, `core.sparseCheckout`, and `core.sparseCheckoutCone`. The working tree files are left intact. This deliberately avoids `git sparse-checkout disable`, which re-materialises the full working tree (expensive on large monorepos).
 
-This can also be enabled without modifying individual pipeline configs by setting `SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG=true` as an agent environment variable — useful for enforcing the behaviour fleet-wide.
-
-**Recommended for:** shared agent fleets with persistent build directories where sparse and non-sparse pipelines may run on the same agent.
+Recommended for shared agent fleets with persistent build directories where sparse and non-sparse pipelines may run on the same agent.
 
 #### `verbose` ('true' or 'false')
 
@@ -128,7 +125,7 @@ steps:
           cleanup_worktree_config: true
 ```
 
-The plugin will clean up stale sparse config in `pre-checkout` (protecting the current run from a previous interrupted job) and again in `post-checkout` (protecting the next run from our own sparse state).
+The plugin will clean up stale sparse config in `pre-exit` (protecting the next job on the same directory from our own sparse state) and again in `pre-checkout` (protecting the current run from a previous interrupted job where `pre-exit` never fired).
 
 ## Testing
 

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -16,16 +16,6 @@ VERBOSE_OPTION="$(plugin_read_config VERBOSE "false")"
 [[ "${VERBOSE_OPTION}" = "true" ]] && set -x
 
 UNSHALLOW_OPTION="$(plugin_read_config POST_CHECKOUT_UNSHALLOW "false")"
-CLEANUP_WORKTREE_CONFIG_OPTION="$(plugin_read_config CLEANUP_WORKTREE_CONFIG "false")"
-if [[ "${SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG:-}" = "true" ]]; then
-  CLEANUP_WORKTREE_CONFIG_OPTION="true"
-fi
-
-# Clean up sparse-checkout config after our checkout so that subsequent non-sparse jobs
-# on the same agent directory are not affected.
-if [[ "${CLEANUP_WORKTREE_CONFIG_OPTION}" = "true" ]]; then
-  cleanup_sparse_checkout_config
-fi
 
 if [[ "${UNSHALLOW_OPTION}" = "true" ]]; then
   if [[ "$(git rev-parse --is-shallow-repository)" = "true" ]]; then

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -15,13 +15,8 @@ setup_error_trap
 VERBOSE_OPTION="$(plugin_read_config VERBOSE "false")"
 [[ "${VERBOSE_OPTION}" = "true" ]] && set -x
 
-CLEANUP_WORKTREE_CONFIG_OPTION="$(plugin_read_config CLEANUP_WORKTREE_CONFIG "false")"
-if [[ "${SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG:-}" = "true" ]]; then
-  CLEANUP_WORKTREE_CONFIG_OPTION="true"
-fi
-
 # Clean up any stale sparse-checkout config left by a previous run (including
 # interrupted jobs where pre-exit never fired) before we start our own checkout.
-if [[ "${CLEANUP_WORKTREE_CONFIG_OPTION}" = "true" ]]; then
+if [[ "$(plugin_read_config CLEANUP_WORKTREE_CONFIG "false")" = "true" ]]; then
   cleanup_sparse_checkout_config
 fi

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -17,6 +17,6 @@ VERBOSE_OPTION="$(plugin_read_config VERBOSE "false")"
 
 # Clean up any stale sparse-checkout config left by a previous run (including
 # interrupted jobs where pre-exit never fired) before we start our own checkout.
-if [[ "$(plugin_read_config CLEANUP_WORKTREE_CONFIG "false")" = "true" ]]; then
+if [[ "$(plugin_read_config CLEANUP_SPARSE_STATE "false")" = "true" ]]; then
   cleanup_sparse_checkout_config
 fi

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -15,27 +15,13 @@ setup_error_trap
 VERBOSE_OPTION="$(plugin_read_config VERBOSE "false")"
 [[ "${VERBOSE_OPTION}" = "true" ]] && set -x
 
-UNSHALLOW_OPTION="$(plugin_read_config POST_CHECKOUT_UNSHALLOW "false")"
 CLEANUP_WORKTREE_CONFIG_OPTION="$(plugin_read_config CLEANUP_WORKTREE_CONFIG "false")"
 if [[ "${SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG:-}" = "true" ]]; then
   CLEANUP_WORKTREE_CONFIG_OPTION="true"
 fi
 
-# Clean up sparse-checkout config after our checkout so that subsequent non-sparse jobs
-# on the same agent directory are not affected.
+# Clean up any stale sparse-checkout config left by a previous run (including
+# interrupted jobs where post-checkout never fired) before we start our own checkout.
 if [[ "${CLEANUP_WORKTREE_CONFIG_OPTION}" = "true" ]]; then
   cleanup_sparse_checkout_config
-fi
-
-if [[ "${UNSHALLOW_OPTION}" = "true" ]]; then
-  if [[ "$(git rev-parse --is-shallow-repository)" = "true" ]]; then
-    log_info "Unshallowing repository"
-    if ! git fetch --unshallow origin; then
-      log_error "Failed to unshallow repository"
-      exit 1
-    fi
-    log_success "Repository unshallowed successfully"
-  else
-    log_info "Repository is not shallow, skipping unshallow"
-  fi
 fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -15,13 +15,8 @@ setup_error_trap
 VERBOSE_OPTION="$(plugin_read_config VERBOSE "false")"
 [[ "${VERBOSE_OPTION}" = "true" ]] && set -x
 
-CLEANUP_WORKTREE_CONFIG_OPTION="$(plugin_read_config CLEANUP_WORKTREE_CONFIG "false")"
-if [[ "${SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG:-}" = "true" ]]; then
-  CLEANUP_WORKTREE_CONFIG_OPTION="true"
-fi
-
 # Clean up sparse-checkout config before the job exits so that subsequent non-sparse
 # jobs on the same agent directory are not affected.
-if [[ "${CLEANUP_WORKTREE_CONFIG_OPTION}" = "true" ]]; then
+if [[ "$(plugin_read_config CLEANUP_WORKTREE_CONFIG "false")" = "true" ]]; then
   cleanup_sparse_checkout_config
 fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -20,8 +20,8 @@ if [[ "${SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG:-}" = "true" ]]; then
   CLEANUP_WORKTREE_CONFIG_OPTION="true"
 fi
 
-# Clean up any stale sparse-checkout config left by a previous run (including
-# interrupted jobs where pre-exit never fired) before we start our own checkout.
+# Clean up sparse-checkout config before the job exits so that subsequent non-sparse
+# jobs on the same agent directory are not affected.
 if [[ "${CLEANUP_WORKTREE_CONFIG_OPTION}" = "true" ]]; then
   cleanup_sparse_checkout_config
 fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -17,6 +17,6 @@ VERBOSE_OPTION="$(plugin_read_config VERBOSE "false")"
 
 # Clean up sparse-checkout config before the job exits so subsequent non-sparse
 # jobs on the same agent directory are not affected.
-if [[ "$(plugin_read_config CLEANUP_WORKTREE_CONFIG "false")" = "true" ]]; then
+if [[ "$(plugin_read_config CLEANUP_SPARSE_STATE "false")" = "true" ]]; then
   cleanup_sparse_checkout_config
 fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -15,7 +15,7 @@ setup_error_trap
 VERBOSE_OPTION="$(plugin_read_config VERBOSE "false")"
 [[ "${VERBOSE_OPTION}" = "true" ]] && set -x
 
-# Clean up sparse-checkout config before the job exits so that subsequent non-sparse
+# Clean up sparse-checkout config before the job exits so subsequent non-sparse
 # jobs on the same agent directory are not affected.
 if [[ "$(plugin_read_config CLEANUP_WORKTREE_CONFIG "false")" = "true" ]]; then
   cleanup_sparse_checkout_config

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -174,6 +174,34 @@ string_strip_suffix() {
 }
 
 # ============================================================================
+# Sparse checkout utilities
+# ============================================================================
+
+# Cleans up sparse-checkout config left behind by git sparse-checkout set.
+# Removes .git/config.worktree and unsets the three related config keys so that
+# subsequent non-sparse jobs on the same agent directory are not affected.
+#
+# Deliberately avoids `git sparse-checkout disable` which re-materialises all
+# files in the working tree (expensive on large monorepos).
+#
+# Covers both modern git (extensions.worktreeConfig + .git/config.worktree) and
+# older git that writes core.sparseCheckout directly into .git/config.
+cleanup_sparse_checkout_config() {
+  if [[ ! -d .git ]]; then
+    log_info "No .git directory found, skipping sparse-checkout config cleanup"
+    return 0
+  fi
+  log_info "Cleaning up sparse-checkout config"
+  # Unset the extension flag first so git does not look for the worktree config
+  # file during subsequent config operations.
+  git config --unset extensions.worktreeConfig 2>/dev/null || true
+  rm -f .git/config.worktree
+  git config --unset core.sparseCheckout 2>/dev/null || true
+  git config --unset core.sparseCheckoutCone 2>/dev/null || true
+  log_success "Sparse-checkout config cleaned up"
+}
+
+# ============================================================================
 # File utilities
 # ============================================================================
 

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -197,7 +197,7 @@ cleanup_sparse_checkout_config() {
   # subsequent non-sparse jobs see all files. These bits are set by
   # `git sparse-checkout set` and persist independently of config entries.
   # Using update-index avoids materialising files to disk (unlike disable).
-  git ls-files -t 2>/dev/null | awk '/^S /{print substr($0, 3)}' | xargs git update-index --no-skip-worktree -- 2>/dev/null || true
+  git ls-files -z | git update-index -z --no-skip-worktree --stdin || true
   # Unset the extension flag first so git does not look for the worktree config
   # file during subsequent config operations.
   git config --unset extensions.worktreeConfig 2>/dev/null || true

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -177,9 +177,10 @@ string_strip_suffix() {
 # Sparse checkout utilities
 # ============================================================================
 
-# Cleans up sparse-checkout config left behind by git sparse-checkout set.
-# Removes .git/config.worktree and unsets the three related config keys so that
-# subsequent non-sparse jobs on the same agent directory are not affected.
+# Cleans up sparse-checkout state left behind by git sparse-checkout set.
+# Removes .git/config.worktree, unsets the three related config keys, and clears
+# per-file skip-worktree bits from the index so that subsequent non-sparse jobs
+# on the same agent directory are not affected.
 #
 # Deliberately avoids `git sparse-checkout disable` which re-materialises all
 # files in the working tree (expensive on large monorepos).
@@ -192,6 +193,11 @@ cleanup_sparse_checkout_config() {
     return 0
   fi
   log_info "Cleaning up sparse-checkout config"
+  # Clear skip-worktree bits from the index before touching config so that
+  # subsequent non-sparse jobs see all files. These bits are set by
+  # `git sparse-checkout set` and persist independently of config entries.
+  # Using update-index avoids materialising files to disk (unlike disable).
+  git ls-files -t 2>/dev/null | awk '/^S /{print substr($0, 3)}' | xargs git update-index --no-skip-worktree -- 2>/dev/null || true
   # Unset the extension flag first so git does not look for the worktree config
   # file during subsequent config operations.
   git config --unset extensions.worktreeConfig 2>/dev/null || true

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -177,29 +177,18 @@ string_strip_suffix() {
 # Sparse checkout utilities
 # ============================================================================
 
-# Cleans up sparse-checkout state left behind by git sparse-checkout set.
-# Removes .git/config.worktree, unsets the three related config keys, and clears
-# per-file skip-worktree bits from the index so that subsequent non-sparse jobs
-# on the same agent directory are not affected.
-#
-# Deliberately avoids `git sparse-checkout disable` which re-materialises all
-# files in the working tree (expensive on large monorepos).
-#
-# Covers both modern git (extensions.worktreeConfig + .git/config.worktree) and
-# older git that writes core.sparseCheckout directly into .git/config.
+# Tears down sparse-checkout state without re-materialising the working tree
+# (unlike `git sparse-checkout disable`, which is expensive on large monorepos).
 cleanup_sparse_checkout_config() {
   if [[ ! -d .git ]]; then
     log_info "No .git directory found, skipping sparse-checkout config cleanup"
     return 0
   fi
   log_info "Cleaning up sparse-checkout config"
-  # Clear skip-worktree bits from the index before touching config so that
-  # subsequent non-sparse jobs see all files. These bits are set by
-  # `git sparse-checkout set` and persist independently of config entries.
-  # Using update-index avoids materialising files to disk (unlike disable).
+  # Paths without skip-worktree set are no-ops, so feeding every tracked path
+  # stays index-only and cheap even on large repos. -z handles special chars.
   git ls-files -z | git update-index -z --no-skip-worktree --stdin || true
-  # Unset the extension flag first so git does not look for the worktree config
-  # file during subsequent config operations.
+  # Unset extension first so git ignores the worktree config we're about to delete.
   git config --unset extensions.worktreeConfig 2>/dev/null || true
   rm -f .git/config.worktree
   git config --unset core.sparseCheckout 2>/dev/null || true

--- a/plugin.yml
+++ b/plugin.yml
@@ -16,7 +16,7 @@ configuration:
     clean_checkout:
       type: boolean
       default: false
-    cleanup_worktree_config:
+    cleanup_sparse_state:
       type: boolean
       default: false
     verbose:

--- a/plugin.yml
+++ b/plugin.yml
@@ -16,6 +16,9 @@ configuration:
     clean_checkout:
       type: boolean
       default: false
+    cleanup_worktree_config:
+      type: boolean
+      default: false
     verbose:
       type: boolean
       default: false

--- a/tests/post-checkout.bats
+++ b/tests/post-checkout.bats
@@ -7,9 +7,6 @@ setup() {
 
 teardown() {
   cd "$HOOK_DIR" 2>/dev/null || true
-  if [[ -n "$WORK_DIR" && -d "$WORK_DIR" ]]; then
-    rm -rf "$WORK_DIR"
-  fi
   unstub git 2>/dev/null || true
 }
 
@@ -42,85 +39,6 @@ teardown() {
 
   assert_success
   refute_output --partial 'Unshallowing repository'
-}
-
-@test "Cleanup worktree config enabled - removes config.worktree and unsets all sparse config keys" {
-  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
-
-  WORK_DIR="$(mktemp -d)"
-  mkdir -p "$WORK_DIR/.git"
-  echo '[core]' > "$WORK_DIR/.git/config.worktree"
-
-  stub git \
-    "config --unset extensions.worktreeConfig : true" \
-    "config --unset core.sparseCheckout : true" \
-    "config --unset core.sparseCheckoutCone : true"
-
-  cd "$WORK_DIR"
-  run "$HOOK_DIR/hooks/post-checkout"
-
-  assert_success
-  assert_output --partial 'Cleaning up sparse-checkout config'
-  assert_output --partial 'Sparse-checkout config cleaned up'
-  [[ ! -f "$WORK_DIR/.git/config.worktree" ]]
-}
-
-@test "Cleanup worktree config enabled - succeeds even when no prior sparse config exists" {
-  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
-
-  WORK_DIR="$(mktemp -d)"
-  mkdir -p "$WORK_DIR/.git"
-
-  stub git \
-    "config --unset extensions.worktreeConfig : true" \
-    "config --unset core.sparseCheckout : true" \
-    "config --unset core.sparseCheckoutCone : true"
-
-  cd "$WORK_DIR"
-  run "$HOOK_DIR/hooks/post-checkout"
-
-  assert_success
-  assert_output --partial 'Cleaning up sparse-checkout config'
-  assert_output --partial 'Sparse-checkout config cleaned up'
-}
-
-@test "Cleanup worktree config enabled - skips when no .git directory" {
-  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
-
-  WORK_DIR="$(mktemp -d)"
-
-  cd "$WORK_DIR"
-  run "$HOOK_DIR/hooks/post-checkout"
-
-  assert_success
-  assert_output --partial 'No .git directory found, skipping sparse-checkout config cleanup'
-  refute_output --partial 'Cleaning up sparse-checkout config'
-}
-
-@test "Cleanup worktree config enabled via SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG env var" {
-  unset BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG
-  export SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
-
-  WORK_DIR="$(mktemp -d)"
-  mkdir -p "$WORK_DIR/.git"
-
-  stub git \
-    "config --unset extensions.worktreeConfig : true" \
-    "config --unset core.sparseCheckout : true" \
-    "config --unset core.sparseCheckoutCone : true"
-
-  cd "$WORK_DIR"
-  run "$HOOK_DIR/hooks/post-checkout"
-
-  assert_success
-  assert_output --partial 'Cleaning up sparse-checkout config'
-}
-
-@test "Cleanup worktree config not configured - no cleanup runs" {
-  run "$HOOK_DIR"/hooks/post-checkout
-
-  assert_success
-  refute_output --partial 'sparse-checkout config'
 }
 
 @test "Unshallow enabled but fetch fails exits with error" {

--- a/tests/post-checkout.bats
+++ b/tests/post-checkout.bats
@@ -5,6 +5,14 @@ setup() {
   HOOK_DIR="$PWD"
 }
 
+teardown() {
+  cd "$HOOK_DIR" 2>/dev/null || true
+  if [[ -n "$WORK_DIR" && -d "$WORK_DIR" ]]; then
+    rm -rf "$WORK_DIR"
+  fi
+  unstub git 2>/dev/null || true
+}
+
 @test "Unshallow enabled and repo is shallow runs git fetch --unshallow" {
   export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_POST_CHECKOUT_UNSHALLOW="true"
 
@@ -16,8 +24,6 @@ setup() {
   assert_success
   assert_output --partial 'Unshallowing repository'
   assert_output --partial 'Repository unshallowed successfully'
-
-  unstub git
 }
 
 @test "Unshallow enabled and repo is not shallow skips unshallow" {
@@ -29,8 +35,6 @@ setup() {
 
   assert_success
   assert_output --partial 'Repository is not shallow, skipping unshallow'
-
-  unstub git
 }
 
 @test "Unshallow not configured skips post-checkout operations" {
@@ -43,92 +47,73 @@ setup() {
 @test "Cleanup worktree config enabled - removes config.worktree and unsets all sparse config keys" {
   export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
 
-  local work_dir
-  work_dir="$(mktemp -d)"
-  mkdir -p "$work_dir/.git"
-  echo '[core]' > "$work_dir/.git/config.worktree"
+  WORK_DIR="$(mktemp -d)"
+  mkdir -p "$WORK_DIR/.git"
+  echo '[core]' > "$WORK_DIR/.git/config.worktree"
 
   stub git \
     "config --unset extensions.worktreeConfig : true" \
     "config --unset core.sparseCheckout : true" \
     "config --unset core.sparseCheckoutCone : true"
 
-  cd "$work_dir"
+  cd "$WORK_DIR"
   run "$HOOK_DIR/hooks/post-checkout"
-  cd "$HOOK_DIR"
 
   assert_success
   assert_output --partial 'Cleaning up sparse-checkout config'
   assert_output --partial 'Sparse-checkout config cleaned up'
-  [[ ! -f "$work_dir/.git/config.worktree" ]]
-
-  unstub git
-  rm -rf "$work_dir"
+  [[ ! -f "$WORK_DIR/.git/config.worktree" ]]
 }
 
 @test "Cleanup worktree config enabled - succeeds even when no prior sparse config exists" {
   export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
 
-  local work_dir
-  work_dir="$(mktemp -d)"
-  mkdir -p "$work_dir/.git"
+  WORK_DIR="$(mktemp -d)"
+  mkdir -p "$WORK_DIR/.git"
 
   stub git \
     "config --unset extensions.worktreeConfig : true" \
     "config --unset core.sparseCheckout : true" \
     "config --unset core.sparseCheckoutCone : true"
 
-  cd "$work_dir"
+  cd "$WORK_DIR"
   run "$HOOK_DIR/hooks/post-checkout"
-  cd "$HOOK_DIR"
 
   assert_success
   assert_output --partial 'Cleaning up sparse-checkout config'
   assert_output --partial 'Sparse-checkout config cleaned up'
-
-  unstub git
-  rm -rf "$work_dir"
 }
 
 @test "Cleanup worktree config enabled - skips when no .git directory" {
   export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
 
-  local work_dir
-  work_dir="$(mktemp -d)"
+  WORK_DIR="$(mktemp -d)"
 
-  cd "$work_dir"
+  cd "$WORK_DIR"
   run "$HOOK_DIR/hooks/post-checkout"
-  cd "$HOOK_DIR"
 
   assert_success
   assert_output --partial 'No .git directory found, skipping sparse-checkout config cleanup'
   refute_output --partial 'Cleaning up sparse-checkout config'
-
-  rm -rf "$work_dir"
 }
 
 @test "Cleanup worktree config enabled via SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG env var" {
   unset BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG
   export SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
 
-  local work_dir
-  work_dir="$(mktemp -d)"
-  mkdir -p "$work_dir/.git"
+  WORK_DIR="$(mktemp -d)"
+  mkdir -p "$WORK_DIR/.git"
 
   stub git \
     "config --unset extensions.worktreeConfig : true" \
     "config --unset core.sparseCheckout : true" \
     "config --unset core.sparseCheckoutCone : true"
 
-  cd "$work_dir"
+  cd "$WORK_DIR"
   run "$HOOK_DIR/hooks/post-checkout"
-  cd "$HOOK_DIR"
 
   assert_success
   assert_output --partial 'Cleaning up sparse-checkout config'
-
-  unstub git
-  rm -rf "$work_dir"
 }
 
 @test "Cleanup worktree config not configured - no cleanup runs" {
@@ -148,6 +133,4 @@ setup() {
 
   assert_failure
   assert_output --partial 'Failed to unshallow repository'
-
-  unstub git
 }

--- a/tests/pre-checkout.bats
+++ b/tests/pre-checkout.bats
@@ -21,6 +21,8 @@ teardown() {
   echo '[core]' > "$WORK_DIR/.git/config.worktree"
 
   stub git \
+    "ls-files -z : true" \
+    "update-index -z --no-skip-worktree --stdin : true" \
     "config --unset extensions.worktreeConfig : true" \
     "config --unset core.sparseCheckout : true" \
     "config --unset core.sparseCheckoutCone : true"
@@ -41,6 +43,8 @@ teardown() {
   mkdir -p "$WORK_DIR/.git"
 
   stub git \
+    "ls-files -z : true" \
+    "update-index -z --no-skip-worktree --stdin : true" \
     "config --unset extensions.worktreeConfig : true" \
     "config --unset core.sparseCheckout : true" \
     "config --unset core.sparseCheckoutCone : true"
@@ -64,25 +68,6 @@ teardown() {
   assert_success
   assert_output --partial 'No .git directory found, skipping sparse-checkout config cleanup'
   refute_output --partial 'Cleaning up sparse-checkout config'
-}
-
-@test "Cleanup worktree config enabled via SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG env var" {
-  unset BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG
-  export SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
-
-  WORK_DIR="$(mktemp -d)"
-  mkdir -p "$WORK_DIR/.git"
-
-  stub git \
-    "config --unset extensions.worktreeConfig : true" \
-    "config --unset core.sparseCheckout : true" \
-    "config --unset core.sparseCheckoutCone : true"
-
-  cd "$WORK_DIR"
-  run "$HOOK_DIR/hooks/pre-checkout"
-
-  assert_success
-  assert_output --partial 'Cleaning up sparse-checkout config'
 }
 
 @test "Cleanup worktree config not configured - does nothing" {

--- a/tests/pre-checkout.bats
+++ b/tests/pre-checkout.bats
@@ -5,42 +5,7 @@ setup() {
   HOOK_DIR="$PWD"
 }
 
-@test "Unshallow enabled and repo is shallow runs git fetch --unshallow" {
-  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_POST_CHECKOUT_UNSHALLOW="true"
-
-  stub git "rev-parse --is-shallow-repository : echo 'true'" \
-           "fetch --unshallow origin : echo 'git fetch unshallow'"
-
-  run "$HOOK_DIR"/hooks/post-checkout
-
-  assert_success
-  assert_output --partial 'Unshallowing repository'
-  assert_output --partial 'Repository unshallowed successfully'
-
-  unstub git
-}
-
-@test "Unshallow enabled and repo is not shallow skips unshallow" {
-  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_POST_CHECKOUT_UNSHALLOW="true"
-
-  stub git "rev-parse --is-shallow-repository : echo 'false'"
-
-  run "$HOOK_DIR"/hooks/post-checkout
-
-  assert_success
-  assert_output --partial 'Repository is not shallow, skipping unshallow'
-
-  unstub git
-}
-
-@test "Unshallow not configured skips post-checkout operations" {
-  run "$HOOK_DIR"/hooks/post-checkout
-
-  assert_success
-  refute_output --partial 'Unshallowing repository'
-}
-
-@test "Cleanup worktree config enabled - removes config.worktree and unsets all sparse config keys" {
+@test "Cleanup worktree config enabled - cleans up stale sparse config before checkout" {
   export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
 
   local work_dir
@@ -54,7 +19,7 @@ setup() {
     "config --unset core.sparseCheckoutCone : true"
 
   cd "$work_dir"
-  run "$HOOK_DIR/hooks/post-checkout"
+  run "$HOOK_DIR/hooks/pre-checkout"
   cd "$HOOK_DIR"
 
   assert_success
@@ -79,7 +44,7 @@ setup() {
     "config --unset core.sparseCheckoutCone : true"
 
   cd "$work_dir"
-  run "$HOOK_DIR/hooks/post-checkout"
+  run "$HOOK_DIR/hooks/pre-checkout"
   cd "$HOOK_DIR"
 
   assert_success
@@ -90,14 +55,14 @@ setup() {
   rm -rf "$work_dir"
 }
 
-@test "Cleanup worktree config enabled - skips when no .git directory" {
+@test "Cleanup worktree config enabled - skips when no .git directory exists yet" {
   export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
 
   local work_dir
   work_dir="$(mktemp -d)"
 
   cd "$work_dir"
-  run "$HOOK_DIR/hooks/post-checkout"
+  run "$HOOK_DIR/hooks/pre-checkout"
   cd "$HOOK_DIR"
 
   assert_success
@@ -121,7 +86,7 @@ setup() {
     "config --unset core.sparseCheckoutCone : true"
 
   cd "$work_dir"
-  run "$HOOK_DIR/hooks/post-checkout"
+  run "$HOOK_DIR/hooks/pre-checkout"
   cd "$HOOK_DIR"
 
   assert_success
@@ -131,23 +96,9 @@ setup() {
   rm -rf "$work_dir"
 }
 
-@test "Cleanup worktree config not configured - no cleanup runs" {
-  run "$HOOK_DIR"/hooks/post-checkout
+@test "Cleanup worktree config not configured - does nothing" {
+  run "$HOOK_DIR/hooks/pre-checkout"
 
   assert_success
   refute_output --partial 'sparse-checkout config'
-}
-
-@test "Unshallow enabled but fetch fails exits with error" {
-  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_POST_CHECKOUT_UNSHALLOW="true"
-
-  stub git "rev-parse --is-shallow-repository : echo 'true'" \
-           "fetch --unshallow origin : exit 1"
-
-  run "$HOOK_DIR"/hooks/post-checkout
-
-  assert_failure
-  assert_output --partial 'Failed to unshallow repository'
-
-  unstub git
 }

--- a/tests/pre-checkout.bats
+++ b/tests/pre-checkout.bats
@@ -13,8 +13,8 @@ teardown() {
   unstub git 2>/dev/null || true
 }
 
-@test "Cleanup worktree config enabled - cleans up stale sparse config before checkout" {
-  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
+@test "Cleanup sparse state enabled - cleans up stale sparse config before checkout" {
+  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_SPARSE_STATE="true"
 
   WORK_DIR="$(mktemp -d)"
   mkdir -p "$WORK_DIR/.git"
@@ -36,8 +36,8 @@ teardown() {
   [[ ! -f "$WORK_DIR/.git/config.worktree" ]]
 }
 
-@test "Cleanup worktree config enabled - succeeds even when no prior sparse config exists" {
-  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
+@test "Cleanup sparse state enabled - succeeds even when no prior sparse config exists" {
+  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_SPARSE_STATE="true"
 
   WORK_DIR="$(mktemp -d)"
   mkdir -p "$WORK_DIR/.git"
@@ -57,8 +57,8 @@ teardown() {
   assert_output --partial 'Sparse-checkout config cleaned up'
 }
 
-@test "Cleanup worktree config enabled - skips when no .git directory exists yet" {
-  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
+@test "Cleanup sparse state enabled - skips when no .git directory exists yet" {
+  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_SPARSE_STATE="true"
 
   WORK_DIR="$(mktemp -d)"
 
@@ -70,7 +70,7 @@ teardown() {
   refute_output --partial 'Cleaning up sparse-checkout config'
 }
 
-@test "Cleanup worktree config not configured - does nothing" {
+@test "Cleanup sparse state not configured - does nothing" {
   run "$HOOK_DIR/hooks/pre-checkout"
 
   assert_success

--- a/tests/pre-checkout.bats
+++ b/tests/pre-checkout.bats
@@ -5,95 +5,84 @@ setup() {
   HOOK_DIR="$PWD"
 }
 
+teardown() {
+  cd "$HOOK_DIR" 2>/dev/null || true
+  if [[ -n "$WORK_DIR" && -d "$WORK_DIR" ]]; then
+    rm -rf "$WORK_DIR"
+  fi
+  unstub git 2>/dev/null || true
+}
+
 @test "Cleanup worktree config enabled - cleans up stale sparse config before checkout" {
   export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
 
-  local work_dir
-  work_dir="$(mktemp -d)"
-  mkdir -p "$work_dir/.git"
-  echo '[core]' > "$work_dir/.git/config.worktree"
+  WORK_DIR="$(mktemp -d)"
+  mkdir -p "$WORK_DIR/.git"
+  echo '[core]' > "$WORK_DIR/.git/config.worktree"
 
   stub git \
     "config --unset extensions.worktreeConfig : true" \
     "config --unset core.sparseCheckout : true" \
     "config --unset core.sparseCheckoutCone : true"
 
-  cd "$work_dir"
+  cd "$WORK_DIR"
   run "$HOOK_DIR/hooks/pre-checkout"
-  cd "$HOOK_DIR"
 
   assert_success
   assert_output --partial 'Cleaning up sparse-checkout config'
   assert_output --partial 'Sparse-checkout config cleaned up'
-  [[ ! -f "$work_dir/.git/config.worktree" ]]
-
-  unstub git
-  rm -rf "$work_dir"
+  [[ ! -f "$WORK_DIR/.git/config.worktree" ]]
 }
 
 @test "Cleanup worktree config enabled - succeeds even when no prior sparse config exists" {
   export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
 
-  local work_dir
-  work_dir="$(mktemp -d)"
-  mkdir -p "$work_dir/.git"
+  WORK_DIR="$(mktemp -d)"
+  mkdir -p "$WORK_DIR/.git"
 
   stub git \
     "config --unset extensions.worktreeConfig : true" \
     "config --unset core.sparseCheckout : true" \
     "config --unset core.sparseCheckoutCone : true"
 
-  cd "$work_dir"
+  cd "$WORK_DIR"
   run "$HOOK_DIR/hooks/pre-checkout"
-  cd "$HOOK_DIR"
 
   assert_success
   assert_output --partial 'Cleaning up sparse-checkout config'
   assert_output --partial 'Sparse-checkout config cleaned up'
-
-  unstub git
-  rm -rf "$work_dir"
 }
 
 @test "Cleanup worktree config enabled - skips when no .git directory exists yet" {
   export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
 
-  local work_dir
-  work_dir="$(mktemp -d)"
+  WORK_DIR="$(mktemp -d)"
 
-  cd "$work_dir"
+  cd "$WORK_DIR"
   run "$HOOK_DIR/hooks/pre-checkout"
-  cd "$HOOK_DIR"
 
   assert_success
   assert_output --partial 'No .git directory found, skipping sparse-checkout config cleanup'
   refute_output --partial 'Cleaning up sparse-checkout config'
-
-  rm -rf "$work_dir"
 }
 
 @test "Cleanup worktree config enabled via SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG env var" {
   unset BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG
   export SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
 
-  local work_dir
-  work_dir="$(mktemp -d)"
-  mkdir -p "$work_dir/.git"
+  WORK_DIR="$(mktemp -d)"
+  mkdir -p "$WORK_DIR/.git"
 
   stub git \
     "config --unset extensions.worktreeConfig : true" \
     "config --unset core.sparseCheckout : true" \
     "config --unset core.sparseCheckoutCone : true"
 
-  cd "$work_dir"
+  cd "$WORK_DIR"
   run "$HOOK_DIR/hooks/pre-checkout"
-  cd "$HOOK_DIR"
 
   assert_success
   assert_output --partial 'Cleaning up sparse-checkout config'
-
-  unstub git
-  rm -rf "$work_dir"
 }
 
 @test "Cleanup worktree config not configured - does nothing" {

--- a/tests/pre-exit.bats
+++ b/tests/pre-exit.bats
@@ -13,8 +13,8 @@ teardown() {
   unstub git 2>/dev/null || true
 }
 
-@test "Cleanup worktree config enabled - removes config.worktree and unsets all sparse config keys" {
-  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
+@test "Cleanup sparse state enabled - removes config.worktree and unsets all sparse config keys" {
+  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_SPARSE_STATE="true"
 
   WORK_DIR="$(mktemp -d)"
   mkdir -p "$WORK_DIR/.git"
@@ -36,8 +36,8 @@ teardown() {
   [[ ! -f "$WORK_DIR/.git/config.worktree" ]]
 }
 
-@test "Cleanup worktree config enabled - succeeds even when no prior sparse config exists" {
-  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
+@test "Cleanup sparse state enabled - succeeds even when no prior sparse config exists" {
+  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_SPARSE_STATE="true"
 
   WORK_DIR="$(mktemp -d)"
   mkdir -p "$WORK_DIR/.git"
@@ -57,8 +57,8 @@ teardown() {
   assert_output --partial 'Sparse-checkout config cleaned up'
 }
 
-@test "Cleanup worktree config enabled - skips when no .git directory" {
-  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
+@test "Cleanup sparse state enabled - skips when no .git directory" {
+  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_SPARSE_STATE="true"
 
   WORK_DIR="$(mktemp -d)"
 
@@ -70,8 +70,8 @@ teardown() {
   refute_output --partial 'Cleaning up sparse-checkout config'
 }
 
-@test "Cleanup worktree config enabled - pipes tracked files to update-index" {
-  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
+@test "Cleanup sparse state enabled - pipes tracked files to update-index" {
+  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_SPARSE_STATE="true"
 
   WORK_DIR="$(mktemp -d)"
   mkdir -p "$WORK_DIR/.git"
@@ -90,7 +90,7 @@ teardown() {
   assert_output --partial 'Sparse-checkout config cleaned up'
 }
 
-@test "Cleanup worktree config not configured - no cleanup runs" {
+@test "Cleanup sparse state not configured - no cleanup runs" {
   run "$HOOK_DIR/hooks/pre-exit"
 
   assert_success

--- a/tests/pre-exit.bats
+++ b/tests/pre-exit.bats
@@ -21,6 +21,7 @@ teardown() {
   echo '[core]' > "$WORK_DIR/.git/config.worktree"
 
   stub git \
+    "ls-files -t : true" \
     "config --unset extensions.worktreeConfig : true" \
     "config --unset core.sparseCheckout : true" \
     "config --unset core.sparseCheckoutCone : true"
@@ -41,6 +42,7 @@ teardown() {
   mkdir -p "$WORK_DIR/.git"
 
   stub git \
+    "ls-files -t : true" \
     "config --unset extensions.worktreeConfig : true" \
     "config --unset core.sparseCheckout : true" \
     "config --unset core.sparseCheckoutCone : true"
@@ -74,6 +76,7 @@ teardown() {
   mkdir -p "$WORK_DIR/.git"
 
   stub git \
+    "ls-files -t : true" \
     "config --unset extensions.worktreeConfig : true" \
     "config --unset core.sparseCheckout : true" \
     "config --unset core.sparseCheckoutCone : true"
@@ -83,6 +86,26 @@ teardown() {
 
   assert_success
   assert_output --partial 'Cleaning up sparse-checkout config'
+}
+
+@test "Cleanup worktree config enabled - clears skip-worktree bits from index" {
+  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
+
+  WORK_DIR="$(mktemp -d)"
+  mkdir -p "$WORK_DIR/.git"
+
+  stub git \
+    "ls-files -t : echo 'S lib/excluded.rb'" \
+    "update-index --no-skip-worktree -- lib/excluded.rb : true" \
+    "config --unset extensions.worktreeConfig : true" \
+    "config --unset core.sparseCheckout : true" \
+    "config --unset core.sparseCheckoutCone : true"
+
+  cd "$WORK_DIR"
+  run "$HOOK_DIR/hooks/pre-exit"
+
+  assert_success
+  assert_output --partial 'Sparse-checkout config cleaned up'
 }
 
 @test "Cleanup worktree config not configured - no cleanup runs" {

--- a/tests/pre-exit.bats
+++ b/tests/pre-exit.bats
@@ -21,7 +21,8 @@ teardown() {
   echo '[core]' > "$WORK_DIR/.git/config.worktree"
 
   stub git \
-    "ls-files -t : true" \
+    "ls-files -z : true" \
+    "update-index -z --no-skip-worktree --stdin : true" \
     "config --unset extensions.worktreeConfig : true" \
     "config --unset core.sparseCheckout : true" \
     "config --unset core.sparseCheckoutCone : true"
@@ -42,7 +43,8 @@ teardown() {
   mkdir -p "$WORK_DIR/.git"
 
   stub git \
-    "ls-files -t : true" \
+    "ls-files -z : true" \
+    "update-index -z --no-skip-worktree --stdin : true" \
     "config --unset extensions.worktreeConfig : true" \
     "config --unset core.sparseCheckout : true" \
     "config --unset core.sparseCheckoutCone : true"
@@ -68,35 +70,15 @@ teardown() {
   refute_output --partial 'Cleaning up sparse-checkout config'
 }
 
-@test "Cleanup worktree config enabled via SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG env var" {
-  unset BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG
-  export SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
-
-  WORK_DIR="$(mktemp -d)"
-  mkdir -p "$WORK_DIR/.git"
-
-  stub git \
-    "ls-files -t : true" \
-    "config --unset extensions.worktreeConfig : true" \
-    "config --unset core.sparseCheckout : true" \
-    "config --unset core.sparseCheckoutCone : true"
-
-  cd "$WORK_DIR"
-  run "$HOOK_DIR/hooks/pre-exit"
-
-  assert_success
-  assert_output --partial 'Cleaning up sparse-checkout config'
-}
-
-@test "Cleanup worktree config enabled - clears skip-worktree bits from index" {
+@test "Cleanup worktree config enabled - pipes tracked files to update-index" {
   export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
 
   WORK_DIR="$(mktemp -d)"
   mkdir -p "$WORK_DIR/.git"
 
   stub git \
-    "ls-files -t : echo 'S lib/excluded.rb'" \
-    "update-index --no-skip-worktree -- lib/excluded.rb : true" \
+    "ls-files -z : echo 'lib/excluded.rb'" \
+    "update-index -z --no-skip-worktree --stdin : true" \
     "config --unset extensions.worktreeConfig : true" \
     "config --unset core.sparseCheckout : true" \
     "config --unset core.sparseCheckoutCone : true"

--- a/tests/pre-exit.bats
+++ b/tests/pre-exit.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+
+setup() {
+  load "${BATS_PLUGIN_PATH}/load.bash"
+  HOOK_DIR="$PWD"
+}
+
+teardown() {
+  cd "$HOOK_DIR" 2>/dev/null || true
+  if [[ -n "$WORK_DIR" && -d "$WORK_DIR" ]]; then
+    rm -rf "$WORK_DIR"
+  fi
+  unstub git 2>/dev/null || true
+}
+
+@test "Cleanup worktree config enabled - removes config.worktree and unsets all sparse config keys" {
+  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
+
+  WORK_DIR="$(mktemp -d)"
+  mkdir -p "$WORK_DIR/.git"
+  echo '[core]' > "$WORK_DIR/.git/config.worktree"
+
+  stub git \
+    "config --unset extensions.worktreeConfig : true" \
+    "config --unset core.sparseCheckout : true" \
+    "config --unset core.sparseCheckoutCone : true"
+
+  cd "$WORK_DIR"
+  run "$HOOK_DIR/hooks/pre-exit"
+
+  assert_success
+  assert_output --partial 'Cleaning up sparse-checkout config'
+  assert_output --partial 'Sparse-checkout config cleaned up'
+  [[ ! -f "$WORK_DIR/.git/config.worktree" ]]
+}
+
+@test "Cleanup worktree config enabled - succeeds even when no prior sparse config exists" {
+  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
+
+  WORK_DIR="$(mktemp -d)"
+  mkdir -p "$WORK_DIR/.git"
+
+  stub git \
+    "config --unset extensions.worktreeConfig : true" \
+    "config --unset core.sparseCheckout : true" \
+    "config --unset core.sparseCheckoutCone : true"
+
+  cd "$WORK_DIR"
+  run "$HOOK_DIR/hooks/pre-exit"
+
+  assert_success
+  assert_output --partial 'Cleaning up sparse-checkout config'
+  assert_output --partial 'Sparse-checkout config cleaned up'
+}
+
+@test "Cleanup worktree config enabled - skips when no .git directory" {
+  export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
+
+  WORK_DIR="$(mktemp -d)"
+
+  cd "$WORK_DIR"
+  run "$HOOK_DIR/hooks/pre-exit"
+
+  assert_success
+  assert_output --partial 'No .git directory found, skipping sparse-checkout config cleanup'
+  refute_output --partial 'Cleaning up sparse-checkout config'
+}
+
+@test "Cleanup worktree config enabled via SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG env var" {
+  unset BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG
+  export SPARSE_CHECKOUT_CLEANUP_WORKTREE_CONFIG="true"
+
+  WORK_DIR="$(mktemp -d)"
+  mkdir -p "$WORK_DIR/.git"
+
+  stub git \
+    "config --unset extensions.worktreeConfig : true" \
+    "config --unset core.sparseCheckout : true" \
+    "config --unset core.sparseCheckoutCone : true"
+
+  cd "$WORK_DIR"
+  run "$HOOK_DIR/hooks/pre-exit"
+
+  assert_success
+  assert_output --partial 'Cleaning up sparse-checkout config'
+}
+
+@test "Cleanup worktree config not configured - no cleanup runs" {
+  run "$HOOK_DIR/hooks/pre-exit"
+
+  assert_success
+  refute_output --partial 'sparse-checkout config'
+}


### PR DESCRIPTION
## Add `cleanup_sparse_state` option to prevent sparse-checkout state leaking between jobs

### Problem

The plugin uses a `BUILDKITE_BUILD_CHECKOUT_PATH` with a `-sparse` appended suffix to isolate sparse vs. non-sparse agent checkouts. If `BUILDKITE_BUILD_CHECKOUT_PATH` is overridden back to a common/persistent build directory after execution of the plugin's `environment` hook this isolation breaks.

`git sparse-checkout` leaves state behind across jobs: `.git/config.worktree`, three config keys (`extensions.worktreeConfig`, `core.sparseCheckout`, `core.sparseCheckoutCone`), and per-file skip-worktree bits on the index. A subsequent non-sparse job on the same directory silently inherits these, causing checkouts to appear to succeed while files outside the prior sparse paths are missing.

### Fix

Using https://github.com/buildkite-plugins/sparse-checkout-buildkite-plugin/pull/35 for reference, this adds a new (opt-in) boolean plugin option `cleanup_sparse_state` (default `false`). When enabled, the plugin tears down all three layers of sparse state:

- Clears skip-worktree bits via `git ls-files -z | git update-index -z --no-skip-worktree --stdin`
- Unsets the three config keys
- Removes `.git/config.worktree`

Deliberately avoids `git sparse-checkout disable`, which re-materialises the full working tree. Using the Linux kernel repo as a benchmark, this approach was ~100ms vs. ~9s with `disable` (~85x faster).

Cleanup runs in two hooks:

- `pre-exit` — primary teardown, runs after the job command so sparse state stays active during the command itself.
- `pre-checkout` — safety net for cases where a prior job's `pre-exit` never fired (agent SIGKILL, crash, power loss).

### Usage

```yaml
steps:
  - label: "Sparse build"
    command: "make build"
    plugins:
      - sparse-checkout#v1.7.0:
          paths:
            - src
          cleanup_sparse_state: true
```

This plugin option can also be enabled at an agent level with `export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEANUP_SPARSE_STATE=true` inside an `environment` hook.