### PR TITLE
Propagate git's real exit status when the commit fetch fails

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -173,9 +173,13 @@ if [[ "${USE_MERGE_REFSPEC}" != "true" ]]; then
   fi
 
   log_info "Fetching ${BUILDKITE_COMMIT} from origin"
-  if ! git fetch "${FETCH_FLAGS[@]}"; then
+  if FETCH_OUTPUT=$(git fetch "${FETCH_FLAGS[@]}" 2>&1); then
+    [[ -n "${FETCH_OUTPUT}" ]] && printf '%s\n' "${FETCH_OUTPUT}"
+  else
+    fetch_status=$?
+    [[ -n "${FETCH_OUTPUT}" ]] && printf '%s\n' "${FETCH_OUTPUT}" >&2
     log_error "Failed to fetch ${BUILDKITE_COMMIT} from origin"
-    exit 1
+    exit "${fetch_status}"
   fi
 fi
 log_success "Fetch completed successfully"

--- a/tests/checkout.bats
+++ b/tests/checkout.bats
@@ -257,6 +257,22 @@ setup() {
   unstub git
 }
 
+@test "Propagates git's real exit status when fetching the commit fails" {
+  stub ssh-keyscan "* : echo 'keyscan'"
+  stub git \
+    "clean * : echo 'git clean'" \
+    "fetch --depth 1 origin dummy-commit-hash : echo 'fatal: shallow file has changed since we read it' >&2; exit 128"
+
+  run "$PWD"/hooks/checkout
+
+  assert_failure 128
+  assert_output --partial 'fatal: shallow file has changed since we read it'
+  assert_output --partial 'Failed to fetch dummy-commit-hash from origin'
+
+  unstub ssh-keyscan
+  unstub git
+}
+
 @test "Clean checkout handles repository without HEAD gracefully" {
   export BUILDKITE_PLUGIN_SPARSE_CHECKOUT_CLEAN_CHECKOUT="true"
 


### PR DESCRIPTION
On a real fetch failure (e.g. a `fatal: shallow file has changed since we read it` race between concurrent jobs sharing a checkout directory), the checkout hook always exits `1` regardless of the actual underlying git error. That collapses every possible fetch failure into the same exit status, so an `automatic` retry rule scoped to one specific failure class has nothing to match against — it either retries everything that exits `1` (including genuinely broken checkouts) or nothing at all.

This fetch path already had a working example to follow: the merge-ref retry logic from #37 captures and re-raises git's real exit status on failure. This applies the same handling to the plain commit/branch fetch, so retry rules can key off the actual underlying exit code instead.

Covered by a new bats test asserting the hook exits with git's real status (not the previous hardcoded `1`); full existing suite (27/27) and shellcheck pass.